### PR TITLE
Allow passing command line args to interpreter

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -23,6 +23,11 @@
   :type 'file
   :group 'idris)
 
+(defcustom idris-interpreter-flags '()
+  "The command line arguments passed to the Idris interpreter"
+  :type '(repeat string)
+  :group 'idris)
+
 (defvar idris-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map [?\C-c ?\C-l] 'inferior-idris-load-file)

--- a/inferior-idris-mode.el
+++ b/inferior-idris-mode.el
@@ -48,7 +48,11 @@
   "Start an inferior Idris process"
   (interactive)
   (setq inferior-idris-buffer
-        (make-comint "inferior-idris" idris-interpreter-path))
+        (apply #'make-comint
+               "inferior-idrisq"
+               idris-interpreter-path
+               nil
+               idris-interpreter-flags))
   (with-current-buffer inferior-idris-buffer
     (inferior-idris-mode)
     (setq inferior-idris-working-directory nil)


### PR DESCRIPTION
Hi, I added support for passing command line arguments to the interpreter so that I could use Effects which requires passing the "-p effects" flag on the command line. 
