### PR TITLE
Changed all keymap definitions except tab binds to use kbd instead of escapes

### DIFF
--- a/idris-indentation.el
+++ b/idris-indentation.el
@@ -100,9 +100,9 @@
 
 (defconst idris-indentation-mode-map
   (let ((keymap (make-sparse-keymap)))
-    (define-key keymap [?\r] 'idris-newline-and-indent)
-    (define-key keymap [backspace] 'idris-indentation-delete-backward-char)
-    (define-key keymap [?\C-d] 'idris-indentation-delete-char)
+    (define-key keymap (kbd "<RET>") 'idris-newline-and-indent)
+    (define-key keymap (kbd "<DEL>") 'idris-indentation-delete-backward-char)
+    (define-key keymap (kbd "C-d") 'idris-indentation-delete-char)
     keymap))
 
 ;;;###autoload

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -35,13 +35,13 @@
 
 (defvar idris-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [?\C-c ?\C-l] 'idris-load-file)
-    (define-key map [?\C-c ?\C-t] 'idris-type-at-point)
-    (define-key map [?\C-c ?\C-c] 'idris-case-split)
-    (define-key map [?\C-c ?\C-m] 'idris-add-missing)
-    (define-key map [?\C-c ?\C-d] 'idris-add-clause)
-    (define-key map [?\C-c ?\C-w] 'idris-make-with-block)
-    (define-key map [?\C-c ?\C-a] 'idris-proof-search)
+    (define-key map (kbd "C-c C-l") 'idris-load-file)
+    (define-key map (kbd "C-c C-t") 'idris-type-at-point)
+    (define-key map (kbd "C-c C-c") 'idris-case-split)
+    (define-key map (kbd "C-c C-m") 'idris-add-missing)
+    (define-key map (kbd "C-c C-d") 'idris-add-clause)
+    (define-key map (kbd "C-c C-w") 'idris-make-with-block)
+    (define-key map (kbd "C-c C-a") 'idris-proof-search)
     map)
   "Keymap used in Idris mode.")
 

--- a/idris-prover.el
+++ b/idris-prover.el
@@ -95,9 +95,11 @@
 
 (defvar idris-prover-script-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [?\C-n] 'idris-prover-script-forward)
-    (define-key map [?\C-p] 'idris-prover-script-backward)
-    (define-key map [?\t] 'idris-prover-script-complete)
+    (define-key map (kbd "C-n") 'idris-prover-script-forward)
+    (define-key map (kbd "C-p") 'idris-prover-script-backward)
+    ;; Using (kbd "<TAB>") in place of "\t" makes emacs angry, and suggests
+    ;; using the latter form.
+    (define-key map "\t" 'idris-prover-script-complete)
     map)
   "Keymap used in Idris proof script mode.")
 

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -146,14 +146,16 @@
 
 (defvar idris-repl-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [?\r] 'idris-repl-return)
-    (define-key map [?\t] 'idris-repl-complete)
-    (define-key map [home] 'idris-repl-begin-of-prompt)
-    (define-key map [?\C-a] 'idris-repl-begin-of-prompt)
-    (define-key map [?\M-p] 'idris-repl-backward-history)
-    (define-key map [C-up] 'idris-repl-backward-history)
-    (define-key map [?\M-n] 'idris-repl-forward-history)
-    (define-key map [C-down] 'idris-repl-forward-history)
+    (define-key map (kbd "<RET>") 'idris-repl-return)
+    ;; (define-key map (kbd "<TAB>") ...) makes the debugger complain, and
+    ;; suggests this method of binding instead.
+    (define-key map "\t" 'idris-repl-complete)
+    (define-key map (kbd "<home>") 'idris-repl-begin-of-prompt)
+    (define-key map (kbd "C-a") 'idris-repl-begin-of-prompt)
+    (define-key map (kbd "M-p") 'idris-repl-backward-history)
+    (define-key map (kbd "<C-up>") 'idris-repl-backward-history)
+    (define-key map (kbd "M-n") 'idris-repl-forward-history)
+    (define-key map (kbd "<C-down>") 'idris-repl-forward-history)
     map)
   "Keymap used in Idris REPL mode.")
 


### PR DESCRIPTION
For some reason binding `(kbd "<TAB>")` fails and recommends using `"\t"` instead, so I've done this and noted it in the comments because it's surprising. Other than this, all keybinds now use the more readable `kbd` form instead of escapes or event vectors.
