### PR TITLE
Specify lexical-binding on the header line, to keep package.el happy

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-commands.el --- Commands for Emacs passed to idris
+;;; idris-commands.el --- Commands for Emacs passed to idris -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 Hannes Mehnert
 

--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-common-utils.el --- Useful utilities
+;;; idris-common-utils.el --- Useful utilities -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 Hannes Mehnert
 

--- a/idris-compat.el
+++ b/idris-compat.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-compat.el --- compatibility functions for Emacs 24.1
+;;; idris-compat.el --- compatibility functions for Emacs 24.1 -*- lexical-binding: t -*-
 
 ;; This file defines defvar-local, which was introduced in Emacs 24.3.
 

--- a/idris-completion.el
+++ b/idris-completion.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-completion.el --- Completion popup for Idris
+;;; idris-completion.el --- Completion popup for Idris -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 Hannes Mehnert
 

--- a/idris-events.el
+++ b/idris-events.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-events.el --- Logging of events in inferior Idris
+;;; idris-events.el --- Logging of events in inferior Idris -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 Hannes Mehnert
 

--- a/idris-info.el
+++ b/idris-info.el
@@ -1,6 +1,4 @@
-;;; -*- lexical-binding: t -*-
-
-;;; idris-info.el --- Facilities for showing Idris help information
+;;; idris-info.el --- Facilities for showing Idris help information -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014  David Raymond Christiansen
 

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-mode.el --- Major mode for editing Idris code
+;;; idris-mode.el --- Major mode for editing Idris code -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013
 

--- a/idris-prover.el
+++ b/idris-prover.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-prover.el --- Prover mode for Idris
+;;; idris-prover.el --- Prover mode for Idris -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 Hannes Mehnert
 

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;; idris-syntax.el - major mode for editing idris source files
+;;; idris-syntax.el --- idris syntax highlighting -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2013 tim dixon, David Raymond Christiansen and Hannes Mehnert
 ;;

--- a/idris-warnings.el
+++ b/idris-warnings.el
@@ -1,5 +1,4 @@
-;;; -*- lexical-binding: t -*-
-;;; idris-warnings.el --- Mark warnings reported by idris in buffers
+;;; idris-warnings.el --- Mark warnings reported by idris in buffers -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013 Hannes Mehnert
 


### PR DESCRIPTION
I noticed that @david-christiansen committed `lexical-binding` declarations in f64d71813155. The style of these declarations stops package.el from parsing info out of the buffer, which is why the description of `idris-mode` on MELPA is currently blank.

So this pull request fixes that, and also fixes up a couple of malformatted description lines.

But separately, I'd just like to confirm that `idris-mode` does not support Emacs 23, right, despite the presence of `idris-compat`?  If so, I'll submit an additional pull-request specifying a package dependency on Emacs 24.

Cheers,

-Steve
