### PR TITLE
Added new commands for structured comment inserton.

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -262,4 +262,27 @@ type-correct, so loading will fail."
   (interactive)
   (insert "_|_"))
 
+(defun idris-insert-comment-heading-compact (heading)
+  "Insert a compact comment heading at point."
+  (interactive "sEnter Heading: ")
+  (setq title (concat "[ " heading " ]"))
+  (setq dashes (make-string (- 76 (length title) ) ?-))
+  (insert (concat "-- " dashes " " title)))
+
+(defun idris-insert-comment-heading (heading) 
+  "Insert a comment heading at point."
+  (interactive "sEnter Heading: ")
+  (setq dashes (make-string 80 ?-))
+  (insert (concat dashes "\n" "-- " heading "\n" dashes "\n")))
+
+(defun idris-insert-module-doc-template ()
+  "Insert template for documenting modules at point."
+  (setq dashes (make-string 80 ?-))
+  (setq content (concat "-- Module    :\n"
+                        "-- Summary   :\n"
+                        "-- Copyright : (c) " (user-full-name) "\n"
+                        "-- License   : see LICENSE\n"))
+  (insert (concat dashes "\n" content dashes "\n")))
+
 (provide 'idris-commands)
+


### PR DESCRIPTION
- `idris-insert-comment-heading` inserts at point comment headings.
- `idris-insert-comment-heading-compact` inserts at point compact
  headings.
- `idris-insert-module-doc-template` inserts a Haskell inpsired
  comment template at point.
