### PR TITLE
Added indentation handling for the `record` keyword

### DIFF
--- a/idris-indentation.el
+++ b/idris-indentation.el
@@ -538,8 +538,7 @@ Preserves indentation and removes extra whitespace"
 		  (if (not (equal current-token "{"))
 		      (parse-error "Illegal token: %s (expected record update syntax)" current-token))
 		  (idris-indentation-list #'idris-indentation-expression
-					  "}" "," nil)
-		  (setq current-token 'end-tokens)))
+					  "}" "," nil)))
     ("where" . (lambda () (idris-indentation-with-starter
 			   #'idris-indentation-declaration-layout nil t)))
     (":"    . (lambda () (idris-indentation-statement-right #'idris-indentation-type)))


### PR DESCRIPTION
Previously, in a situation such as the following:

```
record Hands : Type where|
```

pressing enter would cause idris-mode to complain of an `Illegal token: where`. It turned out that `idris-mode-indentation` was at least partially unaware of the `record` keyword. It should now handle this correctly.
