### PR TITLE
Add semantic highlighting to REPL.

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -68,4 +68,16 @@ positions before and after executing BODY."
        (prog1 (progn ,@body)
 	 (add-text-properties ,start (point) ,props)))))
 
+(defmacro idris-propertize-spans (spans &rest body)
+  "Execute BODY and add the properties indicated by SPANS to the
+inserted text (that is, relative to point prior to insertion)."
+  (let ((start (cl-gensym)))
+    `(let ((,start (point)))
+       (prog1 (progn ,@body)
+         (cl-loop for (begin length props) in ,spans
+                  do (message "%s" props)
+                  do (add-text-properties (+ ,start begin)
+                                          (+ ,start begin length)
+                                          props))))))
+
 (provide 'idris-common-utils)

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -42,6 +42,30 @@
   :type '(repeat symbol)
   :options '(warnings-tree warnings-repl))
 
+(defface idris-semantic-type-face
+  '((t (:foreground "blue")))
+  "The face to be used to highlight types"
+  :group 'idris-faces)
+
+(defface idris-semantic-data-face
+  '((t (:foreground "red")))
+  "The face to be used to highlight data and constructors"
+  :group 'idris-faces)
+
+(defface idris-semantic-function-face
+  '((t (:foreground "green")))
+  "The face to be used to highlight defined functions"
+  :group 'idris-faces)
+
+(defface idris-semantic-bound-face
+  '((t (:foreground "purple")))
+  "The face to be used to highlight bound variables"
+  :group 'idris-faces)
+
+(defface idris-semantic-implicit-face
+  '((t (:slant italic)))
+  "The face to be used to highlight implicit arguments"
+  :group 'idris-faces)
 
 (defvar idris-mode-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
Depends on https://github.com/idris-lang/Idris-dev/pull/801

This patch does the following: for expression evaluation and :t at the
REPL, it annotates the returned text with colors (as is done in the
console REPL) as well as tooltips. Thus far, these tooltips show
fully-qualified names, but in the future they can show docstrings,
types, etc.
