### PR TITLE
Show ! in the modeline while Idris is busy

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -123,7 +123,12 @@ Invokes `idris-mode-hook'."
 
   ; Handle dirty-bit to avoid extra loads
   (add-hook 'first-change-hook 'idris-make-dirty)
-  (setq mode-name `("Idris " (:eval (if (idris-current-buffer-dirty-p) "(Not loaded)" "(Loaded)")))))
+  (setq mode-name `("Idris"
+                    (:eval (if idris-rex-continuations "!" ""))
+                    " "
+                    (:eval (if (idris-current-buffer-dirty-p)
+                               "(Not loaded)"
+                             "(Loaded)")))))
 
 ;; Automatically use idris-mode for .idr files.
 ;;;###autoload
@@ -136,7 +141,8 @@ Invokes `idris-mode-hook'."
     (if pbuf
         (progn
           (kill-buffer pbuf)
-          (unless (get-buffer pbufname) (idris-kill-buffers)))
+          (unless (get-buffer pbufname) (idris-kill-buffers))
+          (setq idris-rex-continuations nil))
       (idris-kill-buffers))))
 
 (defun idris-kill-buffers ()

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -180,7 +180,8 @@ Invokes `idris-repl-mode-hook'."
     (idris-repl-safe-load-history)
     (add-hook 'kill-buffer-hook
               'idris-repl-safe-save-history nil t))
-  (add-hook 'kill-emacs-hook 'idris-repl-save-all-histories))
+  (add-hook 'kill-emacs-hook 'idris-repl-save-all-histories)
+  (setq mode-name `("Idris-REPL" (:eval (if idris-rex-continuations "!" "")))))
 
 (defun idris-repl-remove-event-hook-function ()
   (setq idris-prompt-string "Idris")


### PR DESCRIPTION
Now, in Idris code and REPL buffers, a ! is shown while the interpreter
is taking care of a request from the user.

Fixes #66.
