### PR TITLE
Prevented extra indentation after a `module` declaration.

### DIFF
--- a/idris-indentation.el
+++ b/idris-indentation.el
@@ -633,8 +633,7 @@ Preserves indentation and removes extra whitespace"
    (lambda ()
      (let ((current-indent (idris-current-column)))
        (idris-indentation-read-next-token)
-       (when (equal current-token 'end-tokens)
-         (idris-indentation-layout #'idris-indentation-toplevel)))) nil))
+       (idris-indentation-layout #'idris-indentation-toplevel))) nil))
 
 (defun idris-indentation-list (parser end sep stmt-sep)
   (idris-indentation-with-starter


### PR DESCRIPTION
This should fix #72.

I found the nature of the fix alarming, so an explanation: in `haskell-mode`, a module-declaration-parser must handle not only things such as `module Hands where` but also `module Hands (feet, Eyes(..)) where`. In this setting, a check to make sure that the end of the module declaration (the symbol `end-tokens` in the  code) had been reached. As far as I'm aware, Idris module declarations can't be decorated in any way, so the indentation should return to top-level mode unconditionally after reading the module name, and we can just remove the check.
