### PR TITLE
Move things around to create a strict dependency order

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -17,6 +17,7 @@
 ;;; Code:
 
 (require 'idris-core)
+(require 'idris-settings)
 (require 'idris-syntax)
 (require 'idris-indentation)
 (require 'idris-repl)
@@ -24,48 +25,6 @@
 (require 'idris-warnings)
 (require 'idris-common-utils)
 
-(defgroup idris nil "Idris mode" :prefix 'idris :group 'languages)
-
-(defcustom idris-interpreter-path "idris"
-  "The path to the Idris interpreter"
-  :type 'file
-  :group 'idris)
-
-(defcustom idris-interpreter-flags '()
-  "The command line arguments passed to the Idris interpreter"
-  :type '(repeat string)
-  :group 'idris)
-
-(defcustom idris-warnings-printing (list 'warnings-tree)
-  "How to print warnings: tree view ('warnings-tree) in REPL ('warnings-repl)"
-  :group 'idris
-  :type '(repeat symbol)
-  :options '(warnings-tree warnings-repl))
-
-(defface idris-semantic-type-face
-  '((t (:foreground "blue")))
-  "The face to be used to highlight types"
-  :group 'idris-faces)
-
-(defface idris-semantic-data-face
-  '((t (:foreground "red")))
-  "The face to be used to highlight data and constructors"
-  :group 'idris-faces)
-
-(defface idris-semantic-function-face
-  '((t (:foreground "green")))
-  "The face to be used to highlight defined functions"
-  :group 'idris-faces)
-
-(defface idris-semantic-bound-face
-  '((t (:foreground "purple")))
-  "The face to be used to highlight bound variables"
-  :group 'idris-faces)
-
-(defface idris-semantic-implicit-face
-  '((t (:slant italic)))
-  "The face to be used to highlight implicit arguments"
-  :group 'idris-faces)
 
 (defvar idris-mode-map
   (let ((map (make-sparse-keymap)))
@@ -97,14 +56,6 @@
     ["Customize idris-mode" (customize-group 'idris) t]
     ))
 
-(defcustom idris-mode-hook '(turn-on-idris-indentation)
-  "Hook to run upon entering Idris mode."
-  :type 'hook
-  :options '(turn-on-idris-indentation))
-
-(defcustom idris-use-yasnippet-expansions t
-  "Use yasnippet if available for completing interactive Idris commands"
-  :type 'boolean)
 
 ;;;###autoload
 (define-derived-mode idris-mode prog-mode "Idris"
@@ -133,24 +84,6 @@ Invokes `idris-mode-hook'."
 ;; Automatically use idris-mode for .idr files.
 ;;;###autoload
 (push '("\\.idr$" . idris-mode) auto-mode-alist)
-
-(defun idris-quit ()
-  (interactive)
-  (let* ((pbufname (idris-buffer-name :process))
-         (pbuf (get-buffer pbufname)))
-    (if pbuf
-        (progn
-          (kill-buffer pbuf)
-          (unless (get-buffer pbufname) (idris-kill-buffers))
-          (setq idris-rex-continuations '()))
-      (idris-kill-buffers))))
-
-(defun idris-kill-buffers ()
-  (idris-warning-reset-all)
-  (setq idris-currently-loaded-buffer nil)
-  ; not killing :events since it it tremendously useful for debuging
-  (let ((bufs (list :repl :proof-obligations :proof-shell :proof-script :log :info :notes)))
-    (dolist (b bufs) (idris-kill-buffer b))))
 
 (provide 'idris-mode)
 ;;; idris-mode.el ends here

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -24,48 +24,11 @@
 ;; Boston, MA 02111-1307, USA.
 
 (require 'idris-core)
+(require 'idris-settings)
 (require 'inferior-idris)
 (require 'idris-common-utils)
 (require 'idris-completion)
 (require 'cl-lib)
-
-(defgroup idris-repl nil "Idris REPL" :prefix 'idris :group 'idris)
-
-(defface idris-repl-prompt-face
-  '((t (:inherit font-lock-keyword-face)))
-  "Face for the prompt in the Idris REPL."
-  :group 'idris-repl)
-
-(defface idris-repl-output-face
-  '((t (:inherit font-lock-string-face)))
-  "Face for Idris output in the Idris REPL."
-  :group 'idris-repl)
-
-(defface idris-repl-input-face
-  '((t (:bold t)))
-  "Face for previous input in the Idris REPL."
-  :group 'idris-repl)
-
-(defface idris-repl-result-face
-  '((t ()))
-  "Face for the result of an evaluation in the Idris REPL."
-  :group 'idris-repl)
-
-(defcustom idris-repl-history-file "~/.idris/idris-history.eld"
-  "File to save the persistent REPL history to."
-  :type 'string
-  :group 'idris-repl)
-
-(defcustom idris-repl-history-size 200
-  "*Maximum number of lines for persistent REPL history."
-  :type 'integer
-  :group 'idris-repl)
-
-(defcustom idris-repl-history-file-coding-system
-  'utf-8-unix
-  "*The coding system for the history file."
-  :type 'symbol
-  :group 'idris-repl)
 
 (defvar idris-prompt-string "Idris"
   "The prompt for the user")
@@ -314,26 +277,6 @@ Invokes `idris-repl-mode-hook'."
             (insert-before-markers "\n")
             (set-marker idris-output-end (1- (point)))))))
     (idris-repl-show-maximum-output)))
-
-(defun idris-repl-semantic-text-props (highlighting)
-  (cl-flet ((get-props (props)
-              (let* ((name (assoc :name props))
-                     (implicit (assoc :implicit props))
-                     (decor (assoc :decor props))
-                     (implicit-face (if (and implicit (equal (cadr implicit) :True))
-                                        '(idris-semantic-implicit-face)
-                                      nil))
-                     (decor-face (if decor
-                                     (cdr (assoc (cadr decor)
-                                                 '((:type idris-semantic-type-face)
-                                                   (:data idris-semantic-data-face)
-                                                   (:function idris-semantic-function-face)
-                                                   (:bound idris-semantic-bound-face))))
-                                          nil)))
-                (list 'help-echo (if name (cadr name) "")
-                      'face (append implicit-face decor-face)))))
-    (cl-loop for (start length meta) in highlighting
-             collecting (list start length (get-props meta)))))
 
 (defun idris-repl-insert-result (string &optional highlighting)
   "Inserts STRING and marks it as evaluation result"

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -1,0 +1,124 @@
+;;; idris-settings.el --- Contains settings for idris-mode
+
+;; Copyright (C) 2013 Hannes Mehnert and David Raymond Christiansen
+
+;; Author: Hannes Mehnert <hannes@mehnert.org>
+
+;; License:
+;; Inspiration is taken from SLIME/DIME (http://common-lisp.net/project/slime/) (https://github.com/dylan-lang/dylan-mode)
+;; Therefore license is GPL
+
+;; This file is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This file is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING. If not, write to
+;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+(require 'idris-core)
+
+;;;; Main settings
+
+(defgroup idris nil "Idris mode" :prefix 'idris :group 'languages)
+
+(defcustom idris-interpreter-path "idris"
+  "The path to the Idris interpreter"
+  :type 'file
+  :group 'idris)
+
+(defcustom idris-interpreter-flags '()
+  "The command line arguments passed to the Idris interpreter"
+  :type '(repeat string)
+  :group 'idris)
+
+(defcustom idris-warnings-printing (list 'warnings-tree)
+  "How to print warnings: tree view ('warnings-tree) in REPL ('warnings-repl)"
+  :group 'idris
+  :type '(repeat symbol)
+  :options '(warnings-tree warnings-repl))
+
+(defface idris-semantic-type-face
+  '((t (:foreground "blue")))
+  "The face to be used to highlight types"
+  :group 'idris-faces)
+
+(defface idris-semantic-data-face
+  '((t (:foreground "red")))
+  "The face to be used to highlight data and constructors"
+  :group 'idris-faces)
+
+(defface idris-semantic-function-face
+  '((t (:foreground "green")))
+  "The face to be used to highlight defined functions"
+  :group 'idris-faces)
+
+(defface idris-semantic-bound-face
+  '((t (:foreground "purple")))
+  "The face to be used to highlight bound variables"
+  :group 'idris-faces)
+
+(defface idris-semantic-implicit-face
+  '((t (:slant italic)))
+  "The face to be used to highlight implicit arguments"
+  :group 'idris-faces)
+
+(defcustom idris-mode-hook '(turn-on-idris-indentation)
+  "Hook to run upon entering Idris mode."
+  :type 'hook
+  :options '(turn-on-idris-indentation)
+  :group 'idris)
+
+(defcustom idris-use-yasnippet-expansions t
+  "Use yasnippet if available for completing interactive Idris commands"
+  :type 'boolean
+  :group 'idris)
+
+;;;; REPL settings
+
+(defgroup idris-repl nil "Idris REPL" :prefix 'idris :group 'idris)
+
+(defface idris-repl-prompt-face
+  '((t (:inherit font-lock-keyword-face)))
+  "Face for the prompt in the Idris REPL."
+  :group 'idris-repl)
+
+(defface idris-repl-output-face
+  '((t (:inherit font-lock-string-face)))
+  "Face for Idris output in the Idris REPL."
+  :group 'idris-repl)
+
+(defface idris-repl-input-face
+  '((t (:bold t)))
+  "Face for previous input in the Idris REPL."
+  :group 'idris-repl)
+
+(defface idris-repl-result-face
+  '((t ()))
+  "Face for the result of an evaluation in the Idris REPL."
+  :group 'idris-repl)
+
+(defcustom idris-repl-history-file "~/.idris/idris-history.eld"
+  "File to save the persistent REPL history to."
+  :type 'string
+  :group 'idris-repl)
+
+(defcustom idris-repl-history-size 200
+  "*Maximum number of lines for persistent REPL history."
+  :type 'integer
+  :group 'idris-repl)
+
+(defcustom idris-repl-history-file-coding-system
+  'utf-8-unix
+  "*The coding system for the history file."
+  :type 'symbol
+  :group 'idris-repl)
+
+(provide 'idris-settings)

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -24,6 +24,8 @@
 ;; Boston, MA 02111-1307, USA.
 
 (require 'idris-core)
+(require 'idris-settings)
+(require 'idris-common-utils)
 (require 'pp)
 (require 'cl-lib)
 (require 'idris-events)
@@ -133,7 +135,7 @@
   (let* ((length (idris-decode-length))
          (start (+ 6 (point)))
          (end (+ start length)))
-    (assert (plusp length))
+    (cl-assert (plusp length))
     (prog1 (save-restriction
              (narrow-to-region start end)
              (read (current-buffer)))
@@ -164,34 +166,6 @@
       (prin1 sexp (current-buffer))
       (buffer-string))))
 
-
-;;; Dispatching of events and helpers
-(defmacro destructure-case (value &rest patterns)
-  "Dispatch VALUE to one of PATTERNS.
-A cross between `case' and `destructuring-bind'.
-The pattern syntax is:
-  ((HEAD . ARGS) . BODY)
-The list of patterns is searched for a HEAD `eq' to the car of
-VALUE. If one is found, the BODY is executed with ARGS bound to the
-corresponding values in the CDR of VALUE."
-  (let ((operator (cl-gensym "op-"))
-	(operands (cl-gensym "rand-"))
-	(tmp (cl-gensym "tmp-")))
-    `(let* ((,tmp ,value)
-	    (,operator (car ,tmp))
-	    (,operands (cdr ,tmp)))
-       (case ,operator
-	 ,@(mapcar (lambda (clause)
-                     (if (eq (car clause) t)
-                         `(t ,@(cdr clause))
-                       (destructuring-bind ((op &rest rands) &rest body) clause
-                         `(,op (destructuring-bind ,rands ,operands
-                                 . ,body)))))
-		   patterns)
-	 ,@(if (eq (caar (last patterns)) t)
-	       '()
-	     `((t (error "ELISP destructure-case failed: %S" ,tmp))))))))
-
 (defvar idris-rex-continuations '()
   "List of (ID . FUNCTION) continuations waiting for RPC results.")
 
@@ -214,7 +188,7 @@ corresponding values in the CDR of VALUE."
                       (funcall (cdr rec) value))
                  (t (error "Unexpected reply: %S %S" id value))))))))
 
-(defmacro* idris-rex ((&rest saved-vars) (sexp) &rest continuations)
+(cl-defmacro idris-rex ((&rest saved-vars) (sexp) &rest continuations)
   "(idris-rex (VAR ...) (SEXP) CLAUSES ...)
 
 Remote EXecute SEXP.


### PR DESCRIPTION
Now, idris-mode compiles cleanly for me in emacs -q.  Hopefully, this
will also fix MELPA problems RE #76.
