### PR TITLE
Add menus for interpreter options

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -58,6 +58,15 @@
     ["Get documentation" idris-docs-at-point t]
     ["Apropos" idris-apropos t]
     "-----------------"
+    ("Interpreter options" :active idris-process
+     ["Show implicits" (idris-set-option :show-implicits t)
+      :visible (not (idris-get-option :show-implicits))]
+     ["Hide implicits" (idris-set-option :show-implicits nil)
+      :visible (idris-get-option :show-implicits)]
+     ["Show error context" (idris-set-option :error-context t)
+      :visible (not (idris-get-option :error-context))]
+     ["Hide error context" (idris-set-option :error-context nil)
+      :visible (idris-get-option :error-context)])
     ["Customize idris-mode" (customize-group 'idris) t]
     ))
 

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -130,6 +130,15 @@
 (easy-menu-define idris-repl-mode-menu idris-repl-mode-map
   "Menu for the Idris REPL mode"
   `("Idris REPL"
+    ("Interpreter options" :active idris-process
+     ["Show implicits" (idris-set-option :show-implicits t)
+      :visible (not (idris-get-option :show-implicits))]
+     ["Hide implicits" (idris-set-option :show-implicits nil)
+      :visible (idris-get-option :show-implicits)]
+     ["Show error context" (idris-set-option :error-context t)
+      :visible (not (idris-get-option :error-context))]
+     ["Hide error context" (idris-set-option :error-context nil)
+      :visible (idris-get-option :error-context)])
     ["Customize idris-mode" (customize-group 'idris) t]
     ["Quit inferior idris process" idris-quit t]
     ))

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -266,5 +266,17 @@ versions cannot deal with that."
              (error "Idris process exited unexpectedly"))
            (accept-process-output idris-process 0.1)))))))
 
+(defun idris-get-options ()
+  (idris-eval '(:get-options)))
+
+(defun idris-get-option (opt)
+  (let ((val (assoc opt (car (idris-get-options)))))
+    (if val
+        (equal (cadr val) :True)
+      (error "Unknown Idris option %s" opt))))
+
+(defun idris-set-option (opt b)
+  (let ((bi (if b :True :False)))
+    (idris-eval `(:set-option ,opt ,bi))))
 
 (provide 'inferior-idris)


### PR DESCRIPTION
Now, settings in the running interpreter can be modified using
menus. Thus far, only showing implicits and error context are supported,
but the system is straightforward to generalize.

This is not done using customize because the typical use case is to
briefly toggle them while debugging, and persistency is not desired.

Relies on https://github.com/idris-lang/Idris-dev/pull/1006
