### PR TITLE
Support highlighting metavariables

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -104,6 +104,7 @@ inserted text (that is, relative to point prior to insertion)."
                                                                  (:data idris-semantic-data-face)
                                                                  (:function idris-semantic-function-face)
                                                                  (:keyword idris-keyword-face)
+                                                                 (:metavar idris-metavariable-face)
                                                                  (:bound idris-semantic-bound-face))))
                                                  nil))
                                    (mousable-face (if (and (not (equal (cadr decor) :bound)) ;non-bound becomes clickable


### PR DESCRIPTION
Support Idris's semantic info on what names are metavariables and use
the same face as in source code.

Relies on https://github.com/idris-lang/Idris-dev/pull/1012
