### PR TITLE
Simple, hacky imenu support via regexps

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -95,6 +95,17 @@ Invokes `idris-mode-hook'."
   ; REPL completion for Idris source
   (set (make-local-variable 'completion-at-point-functions) '(idris-complete-symbol-at-point))
 
+  ; imenu support
+  (set (make-local-variable 'imenu-case-fold-search) nil)
+  (set (make-local-variable 'imenu-generic-expression)
+       '(("Data" "^\\s-*data\\s-+\\(\\sw+\\)" 1)
+         ("Data" "^\\s-*record\\s-+\\(\\sw+\\)" 1)
+         ("Data" "^\\s-*codata\\s-+\\(\\sw+\\)" 1)
+         ("Postulates" "^\\s-*postulate\\s-+\\(\\sw+\\)" 1)
+         ("Classes" "^\\s-*class\\s-+\\(\\sw+\\)" 1)
+         (nil "^\\s-*\\(\\sw+\\)\\s-*:" 1)
+         ("Namespaces" "^\\s-*namespace\\s-+\\(\\sw\\|\\.\\)" 1)))
+
   ; Handle dirty-bit to avoid extra loads
   (add-hook 'first-change-hook 'idris-make-dirty)
   (setq mode-name `("Idris"


### PR DESCRIPTION
This should really be asking the compiler. Also, it doesn't see the difference between constructors and functions. On the other hand, it does allow basic support for speedbar and imenu, so it's better than nothing.

We'll need a batch-mode Idris command to dump tags as well as an ideslave command in order to properly support imenu in the future, so that speedbar can get the tags for not-yet-opened buffers.
