### PR TITLE
Support new :refine command

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -310,6 +310,20 @@ compiler-annotated output. Does not return a line number."
             (delete-region start end))
           (idris-insert-or-expand result))))))
 
+(defun idris-refine (name)
+  "Refine by some name, without recursive proof search"
+  (interactive "MRefine by: ")
+  (let ((what (idris-thing-at-point)))
+    (unless (car what)
+      (error "Could not find a metavariable at point to refine by"))
+    (idris-load-file-sync)
+    (let ((result (car (idris-eval `(:refine ,(cdr what) ,(car what) ,name)))))
+      (save-excursion
+        (let ((start (progn (search-backward "?") (point)))
+              (end (progn (forward-char) (search-forward-regexp "[^a-zA-Z0-9_']") (backward-char) (point))))
+          (delete-region start end))
+        (idris-insert-or-expand result)))))
+
 (defun idris-identifier-backwards-from-point ()
   (let ((identifier-start nil)
         (identifier-end (point))

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -37,6 +37,7 @@
     (define-key map (kbd "C-c C-s") 'idris-add-clause)
     (define-key map (kbd "C-c C-w") 'idris-make-with-block)
     (define-key map (kbd "C-c C-a") 'idris-proof-search)
+    (define-key map (kbd "C-c C-r") 'idris-refine)
     (define-key map (kbd "C-c C-h C-a") 'idris-apropos)
     (define-key map (kbd "C-c _") 'idris-insert-bottom)
     (define-key map (kbd "C-c b") 'idris-ipkg-build)


### PR DESCRIPTION
This relies on a merge of
https://github.com/idris-lang/Idris-dev/pull/1083

The keybinding C-c C-r is based on Agda's default binding for refine.
