### PR TITLE
Maintain a local mirror of Idris options

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -92,6 +92,9 @@ Invokes `idris-mode-hook'."
   (set (make-local-variable 'indent-tabs-mode) nil)
   (set (make-local-variable 'comment-start) "--")
 
+  ; Initialize the local options cache
+  (idris-update-options-cache)
+
   ; REPL completion for Idris source
   (set (make-local-variable 'completion-at-point-functions) '(idris-complete-symbol-at-point))
 


### PR DESCRIPTION
Also, set Idris options asynchronously. This stops the Idris menu from
locking up Emacs while Idris is busy.

Fixes #112.
