### PR TITLE
Don't show absurdly long prompts

### DIFF
--- a/idris-repl.el
+++ b/idris-repl.el
@@ -72,11 +72,16 @@
       (idris-save-marker idris-output-end
         (unless (bolp) (insert-before-markers "\n"))
         (let ((prompt-start (point))
-              (prompt (format "%s> " idris-prompt-string)))
+              (prompt (if (equal idris-repl-prompt-style 'short)
+                          "λΠ> "
+                        (format "%s> " idris-prompt-string))))
           (idris-propertize-region
-           '(face idris-repl-prompt-face read-only t intangible t
-                  idris-repl-prompt t
-                  rear-nonsticky (idris-repl-prompt read-only face intangible))
+           `(face idris-repl-prompt-face
+             read-only t
+             intangible t
+             idris-repl-prompt t
+             help-echo ,idris-prompt-string
+             rear-nonsticky (idris-repl-prompt read-only face intangible))
            (insert-before-markers prompt))
           (set-marker idris-prompt-start prompt-start))))))
 

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -132,4 +132,10 @@ with lots of space for the metavariable buffer."
   :type 'symbol
   :group 'idris-repl)
 
+(defcustom idris-repl-prompt-style 'short
+  "What sort of prompt to show. 'long shows the Idris REPL prompt, while 'short shows a shorter one."
+  :options '(short long)
+  :type 'symbol
+  :group 'idris-repl)
+
 (provide 'idris-settings)


### PR DESCRIPTION
The new customization option idris-repl-prompt-style allows users to
pick between showing the long prompt and just having a lambda-pi prompt
with the name from Idris as a tooltip.

This is relevant following the loading of source dirs from ipkg files.
