### PR TITLE
Clear the compiler notes when beginning load

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -88,7 +88,13 @@
   (idris-ensure-process-and-repl-buffer)
   (if (buffer-file-name)
       (when (idris-current-buffer-dirty-p)
+        ;; Remove warning overlays
         (idris-warning-reset-all)
+        ;; Clear the contents of the compiler notes buffer, if it exists
+        (when (get-buffer idris-notes-buffer-name)
+          (with-current-buffer idris-notes-buffer-name
+            (let ((inhibit-read-only t)) (erase-buffer))))
+        ;; Actually do the loading
         (let* ((fn (buffer-file-name))
                (ipkg-srcdir (idris-ipkg-find-src-dir))
                (srcdir (if ipkg-srcdir

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -43,10 +43,7 @@
         (setq buffer-read-only nil)
         (erase-buffer)
         (if (null notes)
-            (progn
-              (message "Cannot find any defect!")
-              (kill-buffer)
-              nil)
+            nil
           (let ((root (idris-compiler-notes-to-tree notes)))
             (idris-tree-insert root "")
             (insert "\n")


### PR DESCRIPTION
The buffer is no longer killed on lack of contents in order to make it
easier to keep window layouts intact. It happens at the beginning of
loading to make slow typechecking less painful.

Fixes #123.
