### PR TITLE
Allow setting the depth of proof search

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -48,7 +48,7 @@ The following commands are available when there is an inferior Idris process (wh
 * `C-c C-l`: Load the current file into Idris. A prefix version does not switch to the REPL buffer afterwards.
 * `C-c C-s`: Create an initial pattern match clause for a type declaration
 * `C-c C-m`: Add missing pattern-match cases to an existing definition
-* `C-c C-a`: Attempt to solve a metavariable automatically. A prefix argument prompts for hints.
+* `C-c C-a`: Attempt to solve a metavariable automatically. A plain prefix argument prompts for hints, while a numeric prefix argument sets the recursion depth.
 * `C-c C-e`: Extract a metavariable or provisional definition name to an explicit top level definition
 * `C-c C-c`: Case split the pattern variable under point
 * `C-c C-t`: Get the type for the identifier under point. A prefix argument prompts for the name.


### PR DESCRIPTION
This is done with a numeric prefix argument to C-c C-a.

Relies on https://github.com/idris-lang/Idris-dev/pull/1251.
