### PR TITLE
Fix errors from overzealous eldoc

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -353,7 +353,7 @@ compiler-annotated output. Does not return a line number."
 
 (defun idris-eldoc-lookup ()
   "Support for showing type signatures in the modeline when there's a running Idris"
-  (let ((signature (ignore-errors (idris-eval (list :type-of (idris-name-at-point))))))
+  (let ((signature (ignore-errors (idris-eval (list :type-of (idris-name-at-point)) t))))
     (when signature
       (with-temp-buffer
         (idris-propertize-spans (idris-repl-semantic-text-props (cdr signature))


### PR DESCRIPTION
The eldoc support would sometimes cause Idris to return errors, which
would trigger an error buffer by just moving the cursor. This disables
that behavior, making errors in eldoc more silent.
