### PR TITLE
Restore compatibility with 0.9.12

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -86,7 +86,7 @@
   (interactive)
   (when idris-metavariable-show-on-load (idris-list-metavariables)))
 
-(defcustom idris-load-file-success-hook '(idris-list-metavariables)
+(defcustom idris-load-file-success-hook '(idris-list-metavariables-on-load)
   "Functions to call when loading a file is successful"
   :type 'hook
   :options '(idris-list-metavariables-on-load)


### PR DESCRIPTION
This patch, plus removing the metavariable command from the load success hook, makes things work again with Idris 0.9.12.

I believe it supersedes #164, and does the same thing somewhat more elegantly, as it ensures that as much of the same code path is called as possible.
