### PR TITLE
Improve clickable filename code

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -711,7 +711,7 @@ means to not ask for confirmation."
 (defun idris-make-imports-clickable ()
   "Attempt to make imports in the current package into clickable links"
   (interactive)
-  (remove-list-of-text-properties (point-min) (point-max) '(keymap mouse-face help-echo))
+  (idris-clear-file-link-overlays)
   (let ((ipkg-src-dir (idris-ipkg-find-src-dir)))
     (when ipkg-src-dir
       (save-excursion

--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -173,6 +173,16 @@ corresponding values in the CDR of VALUE."
 BUFFER is not supplied or is nil."
   (string= (file-name-extension (buffer-file-name buffer)) "lidr"))
 
+(defun idris-make-file-link-overlay (start end keymap help-echo)
+  (let ((overlay (make-overlay start end)))
+    (overlay-put overlay 'name 'idris-file-link)
+    (overlay-put overlay 'keymap keymap)
+    (overlay-put overlay 'mouse-face 'highlight)
+    (overlay-put overlay 'help-echo help-echo)))
+
+(defun idris-clear-file-link-overlays ()
+  "Remove all file link overlays from the current buffer"
+  (remove-overlays nil nil 'idris-file-link))
 
 (defun idris-make-module-link (start end src-dir)
   "Attempt to make the region between START and END into a
@@ -189,10 +199,7 @@ relative to SRC-DIR"
                    (define-key map [mouse-2] #'(lambda ()
                                                  (interactive)
                                                  (find-file src-name)))
-                   (put-text-property start end 'keymap map)
-                   (put-text-property start end 'mouse-face 'highlight)
-                   (put-text-property start end 'help-echo
-                                      "mouse-2: edit module"))))
+                   (idris-make-file-link-overlay start end map "mouse-2: edit module"))))
       (if (file-exists-p idr)
           (make-link idr)
         (when (file-exists-p lidr)

--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -105,7 +105,7 @@
 (defun idris-ipkg-make-files-clickable ()
   "Make all modules with existing files clickable, where clicking opens them"
   (interactive)
-  (remove-list-of-text-properties (point-min) (point-max) '(keymap mouse-face help-echo))
+  (idris-clear-file-link-overlays)
   (let ((src-dir (idris-ipkg-buffer-src-dir (file-name-directory (buffer-file-name)))))
     ;; Make the sourcedir clickable
     (save-excursion
@@ -119,9 +119,8 @@
           (define-key map [mouse-2] #'(lambda ()
                                         (interactive)
                                         (dired src-dir)))
-          (put-text-property start end 'keymap map)
-          (put-text-property start end 'mouse-face 'highlight)
-          (put-text-property start end 'help-echo (concat "mouse-2: dired " src-dir)))))
+          (idris-make-file-link-overlay start end map
+                                        (concat "mouse-2: dired " src-dir)))))
     ;; Make the modules clickable
     (save-excursion
       (goto-char (point-min))
@@ -138,7 +137,7 @@
     ;; Make the Makefile clickable
     (save-excursion
       (goto-char (point-min))
-      (when (re-search-forward "^makefile\\s-*=\\s-*\\([a-zA-Z/0-9]+\\)")
+      (when (re-search-forward "^makefile\\s-*=\\s-*\\([a-zA-Z/0-9]+\\)" nil t)
         (let ((start (match-beginning 1))
               (end (match-end 1))
               (makefile (concat (file-name-as-directory src-dir) (match-string 1))))
@@ -147,10 +146,7 @@
             (define-key map [mouse-2] #'(lambda ()
                                           (interactive)
                                           (find-file makefile)))
-            (put-text-property start end 'keymap map)
-            (put-text-property start end 'mouse-face 'highlight)
-            (put-text-property start end 'help-echo "mouse-2: edit makefile"))))))))
-
+            (idris-make-file-link-overlay start end map  "mouse-2: edit makefile"))))))))
 
 
 (defun idris-ipkg-enable-clickable-files ()


### PR DESCRIPTION
This now uses overlays instead of text properties, making it much less
likely to conflict with minor modes or commands that set certain
properties.
