### PR TITLE
Support type search

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -363,6 +363,11 @@ compiler-annotated output. Does not return a line number."
   (interactive "sSearch Idris docs for: ")
   (idris-info-for-name :apropos what))
 
+(defun idris-type-search (what)
+  "Search the Idris libraries by fuzzy type matching"
+  (interactive "sSearch for type: ")
+  (idris-info-for-name :interpret (concat ":search " what)))
+
 (defun idris-docs-at-point (thing)
   "Display the internal documentation for the name at point, considered as a global variable"
   (interactive "P")

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -35,7 +35,12 @@
     (define-key map (kbd "C-c C-n") 'idris-load-forward-line)
     (define-key map (kbd "C-c C-p") 'idris-load-backward-line)
     (define-key map (kbd "C-c C-t") 'idris-type-at-point)
-    (define-key map (kbd "C-c C-d") 'idris-docs-at-point)
+    (define-key map (kbd "C-c C-d C-d") 'idris-docs-at-point)
+    (define-key map (kbd "C-c C-d d") 'idris-docs-at-point)
+    (define-key map (kbd "C-c C-d C-a") 'idris-apropos)
+    (define-key map (kbd "C-c C-d a") 'idris-apropos)
+    (define-key map (kbd "C-c C-d C-t") 'idris-type-search)
+    (define-key map (kbd "C-c C-d t") 'idris-type-search)
     (define-key map (kbd "C-c C-c") 'idris-case-split)
     (define-key map (kbd "C-c C-m") 'idris-add-missing)
     (define-key map (kbd "C-c C-e") 'idris-make-lemma)
@@ -43,8 +48,6 @@
     (define-key map (kbd "C-c C-w") 'idris-make-with-block)
     (define-key map (kbd "C-c C-a") 'idris-proof-search)
     (define-key map (kbd "C-c C-r") 'idris-refine)
-    (define-key map (kbd "C-c C-h C-a") 'idris-apropos)
-    (define-key map (kbd "C-c C-h a") 'idris-apropos)
     (define-key map (kbd "C-c _") 'idris-insert-bottom)
     (define-key map (kbd "C-c C-b C-b") 'idris-ipkg-build)
     (define-key map (kbd "C-c C-b b") 'idris-ipkg-build)
@@ -84,6 +87,7 @@
     ["Clean package" idris-ipkg-clean t]
     "-----------------"
     ["Get documentation" idris-docs-at-point t]
+    ["Search for type" idris-type-search t]
     ["Apropos" idris-apropos t]
     "-----------------"
     ("Interpreter options" :active idris-process


### PR DESCRIPTION
This adds straightforward support for :search.

It also rebinds a few keys by default to better follow Emacs conventions
as well as SLIME's. This is together with :search support because it
fits into those keybindings.
