### PR TITLE
Support semantic highlighting of proof state

### DIFF
--- a/idris-prover.el
+++ b/idris-prover.el
@@ -76,10 +76,21 @@ prover, or nil if Idris is not proving anything.")
      '(display-buffer-pop-up-window . nil)))
 
 (defun idris-prover-write-goals (goals)
+  "Write GOALS to the goal buffer.
+If GOALS is a string, it is treated as undecorated text.
+Otherwise, it must be a two-element list whose car is a goal
+string and whose cadr is highlighting information."
+  ;;; COMPATIBILITY: Idris 0.9.13.1 and earlier sent a string here, later versions send
+  ;;; a pair of string and highlighting.
   (with-current-buffer (idris-prover-obligations-buffer)
     (let ((buffer-read-only nil))
       (erase-buffer)
-      (insert goals)))
+      (if (stringp goals)
+          (insert goals)
+        (let ((goals-string (car goals))
+              (goals-spans (cadr goals)))
+          (idris-propertize-spans (idris-repl-semantic-text-props goals-spans)
+            (insert goals-string))))))
   (idris-prover-show-obligations))
 
 (defvar idris-prover-saved-window-configuration nil


### PR DESCRIPTION
This isn't the Right Way, which would be to send all the structural
information, but it's straightforwardly achievable right now and an
improvement on what's there.

Supports the new output from idris-lang/Idris-dev#1369 but will still work with older versions.
