### PR TITLE
Remove idle timers

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -909,27 +909,26 @@ of the term to replace."
           ;; Otherwise do nothing
           "")))))
 
-(defun idris-make-imports-clickable (&optional buffer)
+(defun idris-make-imports-clickable ()
   "Attempt to make imports in the current package into clickable
 links in BUFFER. If BUFFER is nil, use the current buffer."
   (interactive)
-  (with-current-buffer (or buffer (current-buffer))
-    (idris-clear-file-link-overlays 'idris-mode)
-    (let ((ipkg-src-dir (idris-ipkg-find-src-dir)))
-      (when ipkg-src-dir
-        (save-excursion
-          (goto-char (point-min))
-          (while (re-search-forward (if (idris-lidr-p)
-                                        "^> import\\s-+\\([a-zA-Z0-9\\.]+\\)"
-                                      "^import\\s-+\\([a-zA-Z0-9\\.]+\\)") nil t)
-            (let ((start (match-beginning 1)) (end (match-end 1)))
-              (idris-make-module-link start end ipkg-src-dir))))))))
+  (idris-clear-file-link-overlays 'idris-mode)
+  (let ((ipkg-src-dir (idris-ipkg-find-src-dir)))
+    (when ipkg-src-dir
+      (save-excursion
+        (goto-char (point-min))
+        (while (re-search-forward (if (idris-lidr-p)
+                                      "^> import\\s-+\\([a-zA-Z0-9\\.]+\\)"
+                                    "^import\\s-+\\([a-zA-Z0-9\\.]+\\)") nil t)
+          (let ((start (match-beginning 1)) (end (match-end 1)))
+            (idris-make-module-link start end ipkg-src-dir)))))))
 
 (defun idris-enable-clickable-imports ()
   "Enable the generation of clickable module imports for the current buffer"
   (interactive)
-  (let ((buffer (current-buffer)))
-    (run-with-idle-timer 1 t 'idris-make-imports-clickable buffer)))
+  (add-hook 'after-save-hook 'idris-make-imports-clickable)
+  (idris-make-imports-clickable))
 
 (defun idris-set-idris-packages ()
   "Interactively set the `idris-packages' variable"

--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -214,9 +214,9 @@ BUFFER is not supplied or is nil."
     (overlay-put overlay 'mouse-face 'highlight)
     (overlay-put overlay 'help-echo help-echo)))
 
-(defun idris-clear-file-link-overlays (mode)
+(defun idris-clear-file-link-overlays (&optional mode)
   "Remove all file link overlays from the current buffer"
-  (when (eq major-mode mode)
+  (when (or (not mode) (eq major-mode mode))
     (remove-overlays (point-min) (point-max) 'idris-file-link t)))
 
 (defun idris-make-module-link (start end src-dir)

--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -152,7 +152,8 @@
 (defun idris-ipkg-enable-clickable-files ()
   "Enable setting up clickable modules and makefiles on idle Emacs"
   (interactive)
-  (run-with-idle-timer 1 t 'idris-ipkg-make-files-clickable))
+  (add-hook 'after-save-hook 'idris-ipkg-make-files-clickable)
+  (idris-ipkg-make-files-clickable))
 
 ;;; finding ipkg files
 


### PR DESCRIPTION
It seems that idle timers are causing all kinds of problems, so rather
than deal with that complexity, the clickable module feature has been
moved to an after-save-hook.

RE #206
