### PR TITLE
Add optional help text in metavar list and prover

### DIFF
--- a/idris-metavariable-list.el
+++ b/idris-metavariable-list.el
@@ -69,6 +69,13 @@ Invoces `idris-metavariable-list-mode-hook'.")
       (setq buffer-read-only nil)
       (erase-buffer)
       (idris-metavariable-list-mode)
+      (when idris-show-help-text
+        (insert "This buffer displays the unsolved metavariables from the currently-loaded code. ")
+        (insert "Press the [P] buttons to solve the metavariables interactively in the prover.")
+        (let ((fill-column 80))
+          (fill-region (point-min) (point-max)))
+        (insert "\n\n"))
+
       (insert "Metavariables:\n")
       (let ((root (make-idris-tree :item (format "Metavariables (%d)" (length metavar-info))
                                    :kids (mapcar #'idris-tree-for-metavariable metavar-info))))

--- a/idris-prover.el
+++ b/idris-prover.el
@@ -85,6 +85,9 @@ string and whose cadr is highlighting information."
   (with-current-buffer (idris-prover-obligations-buffer)
     (let ((buffer-read-only nil))
       (erase-buffer)
+      (when idris-show-help-text
+        (setq header-line-format
+              "This is a read-only view of your proof state. Prove the lemma in the script buffer."))
       (if (stringp goals)
           (insert goals)
         (let ((goals-string (car goals))
@@ -271,6 +274,16 @@ special prover state."
       (setq idris-prover-script-processing-overlay nil))
     (setq idris-prover-prove-step 0)
     (erase-buffer)
+    (when idris-show-help-text
+      (setq header-line-format
+            (let ((fwd (where-is-internal 'idris-prover-script-forward))
+                  (bak (where-is-internal 'idris-prover-script-backward)))
+            (concat " Write your proof script here."
+                    (if (and fwd bak)
+                        (format "Use %s to advance and %s to retract."
+                                (key-description (car fwd))
+                                (key-description (car bak)))
+                      "")))))
     (unless idris-prover-script-processing
       (setq idris-prover-script-processing (make-marker)))
     (unless idris-prover-script-processed

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -53,6 +53,12 @@
                  (const :tag "Unlimited" nil)))
 
 
+(defcustom idris-show-help-text t
+  "Show explanatory text in idris-mode's auxiliary buffers if
+  non-nil. Advanced users may wish to disable this."
+  :group 'idris
+  :type 'boolean)
+
 ;;; Faces
 (defface idris-active-term-face
   '((((background light))


### PR DESCRIPTION
When idris-show-help-text is non-nil, helpful descriptions are shown in
the prover and metavariables.

fixes #202
