### PR TITLE
Compute idris interpreter arguments from .ipkg

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -40,6 +40,12 @@
 (defvar idris-process-current-working-directory ""
   "Working directory of Idris process")
 
+(defvar idris-command-line-option-functions nil
+  "A list of functions to call to compute the command-line arguments to Idris.
+Each function should take no arguments and return a list of
+strings that are suitable arguments to `start-process'.")
+
+
 (defun idris-buffer-name (type)
   (cl-assert (keywordp type))
   (concat (format "*idris-%s*" (substring (symbol-name type) 1))))

--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -300,6 +300,13 @@ Invokes `idris-ipkg-build-mode-hook'.")
         (insert-file-contents ipkg-file)
         (idris-ipkg-buffer-cmdline-opts)))))
 
+(defun idris-ipkg-flags-for-current-buffer ()
+  (let ((opts (idris-ipkg-find-cmdline-opts)))
+    (if (stringp opts)
+        (split-string opts nil t)
+      nil)))
+
+(add-to-list 'idris-command-line-option-functions 'idris-ipkg-flags-for-current-buffer)
 
 ;;; Settings
 

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -110,5 +110,19 @@ remain."
   (idris-quit)
   (kill-buffer idris-event-buffer-name))
 
+(ert-deftest idris-test-find-cmdline-args ()
+  "Test that idris-mode calculates command line arguments from .ipkg files."
+  ;; Outside of a project, none are found
+  (let ((buffer (find-file "test-data/ProofSearch.idr")))
+    (with-current-buffer buffer
+      (should (null (idris-ipkg-flags-for-current-buffer)))
+      (kill-buffer)))
+  ;; Inside of a project, the correct ones are found
+  (let ((buffer (find-file "test-data/cmdline/src/Command/Line/Test.idr")))
+    (with-current-buffer buffer
+      (should (equal (idris-ipkg-flags-for-current-buffer)
+                     (list "-p" "effects")))
+      (kill-buffer))))
+
 (provide 'idris-tests)
 ;;; idris-tests.el ends here

--- a/test-data/cmdline/commandlinetest.ipkg
+++ b/test-data/cmdline/commandlinetest.ipkg
@@ -1,0 +1,8 @@
+package commandlinetest
+
+-- Command line test
+-- by David Raymond Christiansen
+
+opts = "-p effects"
+sourcedir = src
+modules = Command.Line.Test

--- a/test-data/cmdline/src/Command/Line/Test.idr
+++ b/test-data/cmdline/src/Command/Line/Test.idr
@@ -1,0 +1,1 @@
+module Command.Line.Test


### PR DESCRIPTION
This causes Idris to be invoked with the command line arguments from the .ipkg file.
