### PR TITLE
Better highlighting of keywords

### DIFF
--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -230,7 +230,8 @@
          ;; Bottom
          ("_|_" . 'idris-bottom-face)
          ;; Other keywords
-         (,(regexp-opt idris-keywords 'words) . 'idris-keyword-face)
+         (, (concat "[^a-zA-Z%]\\(" (regexp-opt idris-keywords 'words) "\\)[^a-zA-Z]")
+          (1 'idris-keyword-face t))
          ;; Operators
          (,idris-operator-regexp . 'idris-operator-face)
          ;; Metavariables


### PR DESCRIPTION
Though it's still regexps. This should really be in Haskell instead of Emacs regexps!
