### PR TITLE
Place abandoned proofs on kill ring

### DIFF
--- a/idris-prover.el
+++ b/idris-prover.el
@@ -393,6 +393,9 @@ the length reported by Idris."
      (idris-prover-write-goals goal)
      t)
     (`(:abandon-proof ,_msg ,_target)
+     (with-current-buffer idris-prover-script-buffer-name
+       (copy-region-as-kill (point-min) (point-max))
+       (message "Proof saved to kill ring"))
      (idris-prover-end)
      (idris-repl-write-string "Abandoned proof")
      t)


### PR DESCRIPTION
This allows proofs to be "restarted" by opening the prover again,
yanking the proof script, and advancing through the steps.

Fixes #241.
