### PR TITLE
Change default warning face to red wavy underline

### DIFF
--- a/idris-warnings.el
+++ b/idris-warnings.el
@@ -28,11 +28,10 @@
 (require 'cl-lib)
 
 (defface idris-warning-face
-  `((((class color) (background light))
-     (:underline "orange"))
-    (((class color) (background dark))
-     (:underline "coral"))
-    (t (:underline t)))
+  '((((supports :underline (:style wave)))
+     :underline (:style wave :color "red"))
+    (t
+     :inherit warning))
   "Face for warnings from the compiler."
   :group 'idris-faces)
 


### PR DESCRIPTION
In terminal Emacs, use the default warning face instead. Fixes #253.
