### PR TITLE
#255: Added a dark-background highlight.  

### DIFF
--- a/idris-settings.el
+++ b/idris-settings.el
@@ -94,7 +94,8 @@
   :group 'idris-faces)
 
 (defface idris-loaded-region-face
-  '((t (:background "pale green")))
+  '((((background light)) (:background "pale green"))
+    (((background dark))  (:background "DarkSlateGrey")))
   "The face to use for the currently-loaded region of a buffer"
   :group 'idris-faces)
 


### PR DESCRIPTION
It isn't perfect, but it is better.  

Here's it on zenburn:
![screen shot 2014-09-29 at 13 49 43](https://cloud.githubusercontent.com/assets/545689/4441817/71fdc048-47d7-11e4-9d29-3f35cf4560ab.png)

And on solarized-dark:
![screen shot 2014-09-29 at 13 49 56](https://cloud.githubusercontent.com/assets/545689/4441834/aa9fbf0a-47d7-11e4-8677-645db4aa3715.png)

I chose the colours from http://raebear.net/comp/emacscolors.html (I did try hex values, but that didn't seem to work in xterm-256color)
