### PR TITLE
Current indent + 2 is a valid stop (fix #250)

### DIFF
--- a/idris-simple-indent.el
+++ b/idris-simple-indent.el
@@ -141,13 +141,18 @@ column, `tab-to-tab-stop' is done instead."
                             (if (> this-indentation start-column)
                                 (setq invisible-from this-indentation)
                               (let ((end (line-beginning-position 2)))
-                                (move-to-column start-column)
-                                ;; Is start-column inside a tab on this line?
-                                (if (> (current-column) start-column)
-                                    (backward-char 1))
-                                (or (looking-at "[ \t]")
-                                    (skip-chars-forward "^ \t" end))
                                 (skip-chars-forward " \t" end)
+                                ;; Current indent + 2 is a valid stop
+                                (if (= (current-column) start-column)
+                                    (forward-char 2)
+                                  (progn
+                                    (move-to-column start-column)
+                                    ;; Is start-column inside a tab on this line?
+                                    (if (> (current-column) start-column)
+                                        (backward-char 1))
+                                    (or (looking-at "[ \t]")
+                                        (skip-chars-forward "^ \t" end))
+                                    (skip-chars-forward " \t" end)))
                                 (let ((col (current-column)))
                                   (throw 'idris-simple-indent-break
                                          (if (or (= (point) end)


### PR DESCRIPTION
Fixes #250.

This would lead code bodies in `data`, `instance` and `mutual` blocks to a 2-spaces indentation with `C-j`, which is much nicer than the current indent style.

instead of:

``` idr
mutual
        even : Nat -> Bool
        odd : Nat -> Bool
```

We now have:

``` idr
mutual
  even : Nat -> Bool
  odd : Nat -> Bool
```

(Note: this is a different behavior from [haskell-simple-indent.el](https://github.com/haskell/haskell-mode/blob/master/haskell-simple-indent.el). Personally I always prefer `haskell-indentation`, for `simple-indent` does not indent code blocks in the way I wanted. I'd like to see if someone can bring [idris-indentation](https://github.com/idris-hackers/idris-mode/blob/87ee0433addfa3b49ac15857fb81f82c2bbdb4cc/idris-indentation.el) back, but for now, this workaround fixes the indentation I had trouble with.)
