### PR TITLE
Remove special support for _|_

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -673,11 +673,6 @@ type-correct, so loading will fail."
                 nil
               (list start end completions))))))))
 
-(defun idris-insert-bottom ()
-  "Insert _|_ at point"
-  (interactive)
-  (insert "_|_"))
-
 (defun idris-list-metavariables ()
   "Get a list of currently-open metavariables"
   (interactive)

--- a/idris-keys.el
+++ b/idris-keys.el
@@ -57,7 +57,6 @@
   (local-set-key (kbd "C-c C-w") 'idris-make-with-block)
   (local-set-key (kbd "C-c C-a") 'idris-proof-search)
   (local-set-key (kbd "C-c C-r") 'idris-refine)
-  (local-set-key (kbd "C-c _") 'idris-insert-bottom)
   (local-set-key (kbd "RET") 'idris-newline-and-indent)
   ;; Not using `kbd' due to oddness about backspace and delete
   (local-set-key [delete] 'idris-delete-forward-char)

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -1,4 +1,4 @@
-;;; idris-syntax.el --- idris syntax highlighting -*- lexical-binding: t -*-
+;; idris-syntax.el --- idris syntax highlighting -*- lexical-binding: t -*-
 ;;
 ;; Copyright (C) 2013 tim dixon, David Raymond Christiansen and Hannes Mehnert
 ;;
@@ -78,11 +78,6 @@
 (defface idris-operator-face
   '((t (:inherit font-lock-variable-name-face)))
   "The face to highlight operators with."
-  :group 'idris-faces)
-
-(defface idris-bottom-face
-  '((t (:inherit idris-identifier-face)))
-  "The face used to highlight _|_ in Idris"
   :group 'idris-faces)
 
 (defface idris-char-face
@@ -227,8 +222,6 @@
            (4 'idris-parameter-face))
          ;; Character literals
          ("'\\(?:[^']\\|\\\\.\\)'" . 'idris-char-face)
-         ;; Bottom
-         ("_|_" . 'idris-bottom-face)
          ;; Other keywords
          (, (concat "[^a-zA-Z%]\\(" (regexp-opt idris-keywords 'words) "\\)[^a-zA-Z]")
           (1 'idris-keyword-face t))


### PR DESCRIPTION
Idris has renamed _|_ to "Void", so special commands and highlighting
are no longer necessary.

Fixes #259.
