### PR TITLE
Remove extra autoload cookie

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -125,7 +125,6 @@ Invokes `idris-mode-hook'."
 
 
 ;;; Handy utilities for other modes
-;;;###autoload
 (eval-after-load 'flycheck
   '(progn
      (flycheck-define-checker idris


### PR DESCRIPTION
This is reported to cause problems for one user, and it's hard to see
how it could be useful without having had the mode loaded anyway.

Fixes #258.
