### PR TITLE
Add evil keybindings through a idris-mode hook

### DIFF
--- a/idris-keys.el
+++ b/idris-keys.el
@@ -92,4 +92,17 @@
   (local-set-key (kbd "C-c C-b C-p") 'idris-open-package-file)
   (local-set-key (kbd "C-c C-b p") 'idris-open-package-file))
 
+(defun idris-define-evil-keys ()
+  "Define keys for evil-mode."
+  (when (fboundp 'evil-leader/set-key-for-mode)
+    (evil-leader/set-key-for-mode 'idris-mode
+      "r" 'idris-load-file
+      "t" 'idris-type-at-point
+      "d" 'idris-add-clause
+      "c" 'idris-case-split
+      "w" 'idris-make-with-block
+      "m" 'idris-add-missing
+      "p" 'idris-proof-search
+      "h" 'idris-docs-at-point)))
+
 (provide 'idris-keys)

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -143,18 +143,5 @@ Invokes `idris-mode-hook'."
 
        (add-to-list 'flycheck-checkers 'idris))))
 
-;;; Bindings for evil-mode
-(eval-after-load 'evil-leader
-  '(eval
-    '(evil-leader/set-key-for-mode 'idris-mode
-       "r" 'idris-load-file
-       "t" 'idris-type-at-point
-       "d" 'idris-add-clause
-       "c" 'idris-case-split
-       "w" 'idris-make-with-block
-       "m" 'idris-add-missing
-       "p" 'idris-proof-search
-       "h" 'idris-docs-at-point)))
-
 (provide 'idris-mode)
 ;;; idris-mode.el ends here

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -111,7 +111,8 @@
                              idris-define-editing-keys
                              idris-define-general-keys
                              idris-define-ipkg-keys
-                             idris-define-ipkg-opening-keys)
+                             idris-define-ipkg-opening-keys
+                             idris-define-evil-keys)
   "Hook to run upon entering Idris mode. You should choose at most one indentation style."
   :type 'hook
   :options '(turn-on-idris-simple-indent
@@ -122,7 +123,8 @@
              idris-define-editing-keys
              idris-define-general-keys
              idris-define-ipkg-keys
-             idris-define-ipkg-opening-keys)
+             idris-define-ipkg-opening-keys
+             idris-define-evil-keys)
   :group 'idris)
 
 (defcustom idris-mode-lidr-hook '()


### PR DESCRIPTION
This fixes #272.

I think calling evil-leader/set-key-for-mode in a hook is not idiomatic, but then doing otherwise would mean either
1. changing the way other keybindings are defined to add to idris-mode-map rather than using hooks (that might be more idiomatic too, I'm not sure) so that all keybindings are defined in a more "declarative" manner and customized differently than now; or
2. treat evil keybindings in a special way (with they own custom variable).

The former would mean users would have to redo customizations they might have done. Let me know if you'd prefer something else than what I did in the PR.
