### PR TITLE
Improve highlighting of provisional definitions

### DIFF
--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -188,82 +188,88 @@ syntax table won't support, such as characters."
 ;; This should be a function so that it evaluates `idris-lidr-p` at the correct time
 (defun idris-font-lock-defaults ()
   (cl-flet ((line-start (regexp)
-              (if (idris-lidr-p)
-                  (concat "^>" regexp)
-                (concat "^" regexp))))
+                        (if (idris-lidr-p)
+                            (concat "^>" regexp)
+                          (concat "^" regexp))))
     `('(
-         ;; Documentation comments.
-         (,(line-start "\\s-*\\(|||\\)\\(.+\\)$")
-          (1 font-lock-comment-delimiter-face)
-          (2 font-lock-doc-face))
-         (,(line-start "\\s-*\\(|||\\)\\s-*\\(@\\)\\s-*\\(\\sw+\\)")
-          (1 font-lock-comment-delimiter-face t)
-          (2 font-lock-comment-delimiter-face t)
-          (3 'idris-parameter-face t))
-         ;; %assert_total
-         ("%assert_total" . 'idris-unsafe-face)
-         ;; `%access`, `%default`, etc
-         (,(line-start "\\s-*\\(%\\w+\\)\\s-*\\(.*\\)")
-           (1 'idris-directive-face)
-           (2 'idris-directive-argument-face))
-         ;; Definitions with keywords.
-         (,(format "\\(%s\\) \\(\\w+\\)" (regexp-opt idris-definition-keywords))
-           (1 'idris-keyword-face)
-           (2 'idris-definition-face))
-         ;; Type declarations
-         ;; TODO: this won't match, e.g. f:a
-         (,(line-start "\\s-*\\(\\w+\\|(\\s_+)\\)\\s-+\\(:\\)\\s-+")
-          (1 'idris-definition-face)
-          (2 'idris-colon-face))
-         (,(line-start "\\s-*\\(total\\|partial\\)\\s-+\\(\\w+\\)\\s-+\\(:\\)\\s-+")
-          (1 'idris-keyword-face)
-          (2 'idris-definition-face)
-          (3 'idris-colon-face))
-         ;; "where"-blocks
-         (,(line-start "\\s-+\\(where\\)\\s-+\\(\\w+\\)\s-*\\(.?*\\)\\(=\\)")
-           (1 'idris-keyword-face)
-           (2 'idris-definition-face)
-           (3 'idris-parameter-face)
-           (4 'idris-equals-face))
-         (,(line-start "\\s-+\\(where\\)\\s-+\\(\\w+\\|(\\s_+)\\)\s-*\\(:\\)\\s-*")
-           (1 'idris-keyword-face)
-           (2 'idris-definition-face)
-           (3 'idris-colon-face))
-         (,(line-start "\\s-+\\(where\\)\\s-+\\(total\\|partial\\)\\s-+\\(\\w+\\)\s-*\\(:\\)\\s-*")
-           (1 'idris-keyword-face)
-           (2 'idris-keyword-face)
-           (3 'idris-definition-face)
-           (4 'idris-colon-face))
-         ;; Vanilla definitions with = (and optionally let ... in ...)
-         (,(line-start "\\s-*\\(\\w+\\|(\\s_+)\\)\s-*\\(.*?\\)\\(=\\)")
-           (1 'idris-definition-face)
-           (2 'idris-parameter-face)
-           (3 'idris-equals-face))
-         (,(line-start "\\s-*\\(\\w+\\|(\\s_+)\\)\\s-+\\(.*?\\)\\s-*\\(impossible\\)")
-          (1 'idris-definition-face)
-          (2 'idris-parameter-face)
-          (3 'idris-keyword-face))
-         ;; Definitions using "with"
-         (,(line-start "\\s-*\\(\\w+\\)\s-*\\(.?*\\)\\(with\\)\\(.?*\\)")
-           (1 'idris-definition-face)
-           (2 'idris-parameter-face)
-           (3 'idris-keyword-face)
-           (4 'idris-parameter-face))
-         ;; Other keywords
-         (, (concat "\\(?:[^a-zA-Z%]\\|^\\)\\(" (regexp-opt idris-keywords 'words) "\\)\\(?:[^a-zA-Z]\\|$\\)")
-          (1 'idris-keyword-face))
-         ;; Operators
-         (,idris-operator-regexp . 'idris-operator-face)
-         ;; Metavariables
-         ("\\?[a-zA-Z_]\\w*" . 'idris-metavariable-face)
-         ;; Identifiers
-         ("[a-zA-Z_]\\w*" . 'idris-identifier-face)
-         ;; Scary stuff
-         (,(regexp-opt '("believe_me" "really_believe_me" "assert_total" "assert_smaller" "prim__believe_me"))
-          0 'idris-unsafe-face t)
-         ;; TODO: operator definitions.
-         ;; TODO: let ... in ...
-         ))))
+        ;; Documentation comments.
+        (,(line-start "\\s-*\\(|||\\)\\(.+\\)$")
+         (1 font-lock-comment-delimiter-face)
+         (2 font-lock-doc-face))
+        (,(line-start "\\s-*\\(|||\\)\\s-*\\(@\\)\\s-*\\(\\sw+\\)")
+         (1 font-lock-comment-delimiter-face t)
+         (2 font-lock-comment-delimiter-face t)
+         (3 'idris-parameter-face t))
+        ;; %assert_total
+        ("%assert_total" . 'idris-unsafe-face)
+        ;; `%access`, `%default`, etc
+        (,(line-start "\\s-*\\(%\\w+\\)\\s-*\\(.*\\)")
+         (1 'idris-directive-face)
+         (2 'idris-directive-argument-face))
+        ;; Definitions with keywords.
+        (,(format "\\(%s\\) \\(\\w+\\)" (regexp-opt idris-definition-keywords))
+         (1 'idris-keyword-face)
+         (2 'idris-definition-face))
+        ;; Type declarations
+        ;; TODO: this won't match, e.g. f:a
+        (,(line-start "\\s-*\\(\\w+\\|(\\s_+)\\)\\s-+\\(:\\)\\s-+")
+         (1 'idris-definition-face)
+         (2 'idris-colon-face))
+        (,(line-start "\\s-*\\(total\\|partial\\)\\s-+\\(\\w+\\)\\s-+\\(:\\)\\s-+")
+         (1 'idris-keyword-face)
+         (2 'idris-definition-face)
+         (3 'idris-colon-face))
+        ;; "where"-blocks
+        (,(line-start "\\s-+\\(where\\)\\s-+\\(\\w+\\)\s-*\\(.?*\\)\\(=\\)")
+         (1 'idris-keyword-face)
+         (2 'idris-definition-face)
+         (3 'idris-parameter-face)
+         (4 'idris-equals-face))
+        (,(line-start "\\s-+\\(where\\)\\s-+\\(\\w+\\|(\\s_+)\\)\s-*\\(:\\)\\s-*")
+         (1 'idris-keyword-face)
+         (2 'idris-definition-face)
+         (3 'idris-colon-face))
+        (,(line-start "\\s-+\\(where\\)\\s-+\\(total\\|partial\\)\\s-+\\(\\w+\\)\s-*\\(:\\)\\s-*")
+         (1 'idris-keyword-face)
+         (2 'idris-keyword-face)
+         (3 'idris-definition-face)
+         (4 'idris-colon-face))
+        ;; Provisional definitions with ?=
+        (,(line-start "\\s-*\\(\\w+\\|(\\s_+)\\)\s-*\\(.*?\\)\\(\\?=\\)\\(\\s-*{\\([a-zA-Z_][a-zA-Z_0-9']*\\)}\\)?")
+         (1 'idris-definition-face)
+         (2 'idris-parameter-face)
+         (3 'idris-equals-face)
+         (5 'idris-metavariable-face))
+        ;; Vanilla definitions with = (and optionally let ... in ...)
+        (,(line-start "\\s-*\\(\\w+\\|(\\s_+)\\)\s-*\\(.*?\\)\\(=\\)")
+         (1 'idris-definition-face)
+         (2 'idris-parameter-face)
+         (3 'idris-equals-face))
+        (,(line-start "\\s-*\\(\\w+\\|(\\s_+)\\)\\s-+\\(.*?\\)\\s-*\\(impossible\\)")
+         (1 'idris-definition-face)
+         (2 'idris-parameter-face)
+         (3 'idris-keyword-face))
+        ;; Definitions using "with"
+        (,(line-start "\\s-*\\(\\w+\\)\s-*\\(.?*\\)\\(with\\)\\(.?*\\)")
+         (1 'idris-definition-face)
+         (2 'idris-parameter-face)
+         (3 'idris-keyword-face)
+         (4 'idris-parameter-face))
+        ;; Other keywords
+        (, (concat "\\(?:[^a-zA-Z%]\\|^\\)\\(" (regexp-opt idris-keywords 'words) "\\)\\(?:[^a-zA-Z]\\|$\\)")
+           (1 'idris-keyword-face))
+        ;; Operators
+        (,idris-operator-regexp . 'idris-operator-face)
+        ;; Metavariables
+        ("\\?[a-zA-Z_]\\w*" . 'idris-metavariable-face)
+        ;; Identifiers
+        ("[a-zA-Z_]\\w*" . 'idris-identifier-face)
+        ;; Scary stuff
+        (,(regexp-opt '("believe_me" "really_believe_me" "assert_total" "assert_smaller" "prim__believe_me"))
+         0 'idris-unsafe-face t)
+        ;; TODO: operator definitions.
+        ;; TODO: let ... in ...
+        ))))
 
 
 


### PR DESCRIPTION
Now, the lemma name is given metavariable highlighting and the ?= is
highlighted as a definining equality (just like normal =).

Fixes #281.