### PR TITLE
LIDR-aware syntax search + fix case arrows.

### DIFF
--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -210,7 +210,6 @@ esp. `font-lock-defaults', for details."
         (idris-font-lock-literate-search regexp lidr limit))
     nil))
 
-
 ;; This should be a function so that it evaluates `idris-lidr-p' at the correct time
 (defun idris-font-lock-defaults ()
   (cl-flet ((line-start (regexp)
@@ -219,7 +218,7 @@ esp. `font-lock-defaults', for details."
                           (concat "^" regexp))))
     `('(
         ;; Documentation comments.
-        (,(line-start "\\s-*\\(|||\\)\\(.+\\)$")
+        (,(line-start "\\s-*\\(|||\\)\\(.*\\)$")
          (1 font-lock-comment-delimiter-face)
          (2 font-lock-doc-face))
         (,(line-start "\\s-*\\(|||\\)\\s-*\\(@\\)\\s-*\\(\\sw+\\)")

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -197,10 +197,15 @@ syntax table won't support, such as characters."
 See the documentation for search-based fontification,
 esp. `font-lock-defaults', for details."
   (if (re-search-forward regexp limit t)
-      (if (or (not lidr)
-              (save-excursion
-                (move-beginning-of-line nil)
-                (looking-at-p "^> ")))
+      (if (or (and (not lidr) ;; normal syntax - ensure not in docs
+                   (save-excursion
+                     (move-beginning-of-line nil)
+                     (not (looking-at-p "^\\s-*|||"))))
+              (and lidr
+                   (save-excursion ;; LIDR syntax - ensure in code, not in docs
+                     (move-beginning-of-line nil)
+                     (and (looking-at-p "^> ")
+                          (not (looking-at-p "^>\\s-*|||"))))))
           t
         (idris-font-lock-literate-search regexp lidr limit))
     nil))


### PR DESCRIPTION
As far as I can see, comments, docs, and text portions of LIDR files are
now all free of Idris keyword highlighting. The same technique can later
be used to highlight Markdown in docs.

I believe this fixes #45, finally.

Also, case arrows (=>) are no longer misidentified as definition LHSs, fixing #37.