### PR TITLE
Add a little note about Pop Win

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -178,7 +178,13 @@ Before sending a patch or pull request, please run the automated tests for idris
 
 ## Pop Win
 
-If you haven't already, you should look into [Pop Win](http://www.emacswiki.org/emacs/PopWin). It gets rid of those pesky `*Completions*` or `*compile*` windows that take up half of the Emacs frame. It doesn't work out of the box with idris-mode, but you can add these configuration lines to `~/.emacs` to make it work:
+If you haven't already, you should look into
+[Pop Win](http://www.emacswiki.org/emacs/PopWin). It helps with the management
+those pesky `*Completions*` or `*compile*` windows that take up half of the
+Emacs frame. It can make the window smaller, position it on the page, disable
+selection of it, close it automatically, etc. Pop Win doesn't work out of the
+box with idris-mode, but you can add these configuration lines to `~/.emacs` to
+make it work:
 
 ```elisp
 (push 'idris-compiler-notes-mode popwin:special-display-config)
@@ -189,3 +195,6 @@ If you haven't already, you should look into [Pop Win](http://www.emacswiki.org/
         :stick t)
       popwin:special-display-config)
 ```
+
+Note that this is an incomplete configuration, I've only documented what I've
+encountered thus far.

--- a/readme.markdown
+++ b/readme.markdown
@@ -175,3 +175,17 @@ Before sending a patch or pull request, please run the automated tests for idris
 ## Related packages
 
 [`helm-idris`](https://www.github.com/david-christiansen/helm-idris) builds on `idris-mode` to provide an alternative interface to looking up documentation.
+
+## Pop Win
+
+If you haven't already, you should look into [Pop Win](http://www.emacswiki.org/emacs/PopWin). It gets rid of those pesky `*Completions*` or `*compile*` windows that take up half of the Emacs frame. It doesn't work out of the box with idris-mode, but you can add these configuration lines to `~/.emacs` to make it work:
+
+```elisp
+(push 'idris-compiler-notes-mode popwin:special-display-config)
+(push '(idris-repl-mode
+        :height 0.2
+        :noselect nil
+        :position bottom
+        :stick t)
+      popwin:special-display-config)
+```


### PR DESCRIPTION
Pop Win is an Emacs package that manages those pesky windows like `*Completions*` or `*compile*`, which ordinarily make their own ordinary window. You can think of Pop Win as "a popup blocker for Emacs" - except it doesn't block the windows entirely, it just makes them less annoying. (Although, I'm sure you can configure popwin to block the windows)

Anyway, it doesn't work out of the box with idris mode, so I added instructions to make it work.