### PR TITLE
Properly highlight "import public" directives

### DIFF
--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -217,6 +217,10 @@ esp. `font-lock-defaults', for details."
                             (concat "^>" regexp)
                           (concat "^" regexp))))
     `('(
+        ;; Imports
+        (,(line-start "\\(import\\)\\s-+\\(public\\)")
+         (1 'idris-keyword-face)
+         (2 'idris-keyword-face))
         ;; Documentation comments.
         (,(line-start "\\s-*\\(|||\\)\\(.*\\)$")
          (1 font-lock-comment-delimiter-face)


### PR DESCRIPTION
Then I think it's good enough to call it 0.9.16 so I can update the syntax highlighting for the new FFI and also see if I can get Idris to do some lexing for me.