### PR TITLE
Keyword completion

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -36,6 +36,7 @@
 (require 'idris-metavariable-list)
 (require 'idris-prover)
 (require 'idris-common-utils)
+(require 'idris-syntax)
 
 (require 'cl-lib)
 (require 'thingatpt)
@@ -683,7 +684,22 @@ type-correct, so loading will fail."
           (cl-destructuring-bind (completions _partial) result
             (if (null completions)
                 nil
-              (list start end completions))))))))
+              (list start end completions
+                    :exclusive 'no))))))))
+
+(defun idris-complete-keyword-at-point ()
+  "Attempt to complete the symbol at point as an Idris keyword."
+  (pcase-let* ((all-idris-keywords
+                (append idris-keywords idris-definition-keywords))
+               (`(,identifier ,start ,end)
+                (idris-identifier-backwards-from-point))
+               (candidates (cl-remove-if-not
+                            (apply-partially #'string-prefix-p identifier)
+                            all-idris-keywords)))
+    (if (null candidates)
+        nil
+      (list start end candidates
+            :exclusive 'no))))
 
 (defun idris-list-metavariables ()
   "Get a list of currently-open metavariables"

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -692,14 +692,15 @@ type-correct, so loading will fail."
   (pcase-let* ((all-idris-keywords
                 (append idris-keywords idris-definition-keywords))
                (`(,identifier ,start ,end)
-                (idris-identifier-backwards-from-point))
-               (candidates (cl-remove-if-not
-                            (apply-partially #'string-prefix-p identifier)
-                            all-idris-keywords)))
-    (if (null candidates)
-        nil
-      (list start end candidates
-            :exclusive 'no))))
+                (idris-identifier-backwards-from-point)))
+    (when identifier
+      (let ((candidates (cl-remove-if-not
+                         (apply-partially #'string-prefix-p identifier)
+                         all-idris-keywords)))
+        (if (null candidates)
+            nil
+          (list start end candidates
+                :exclusive 'no))))))
 
 (defun idris-list-metavariables ()
   "Get a list of currently-open metavariables"

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -102,8 +102,10 @@ Invokes `idris-mode-hook'."
   (set (make-local-variable 'parse-sexp-lookup-properties) t)
   (set (make-local-variable 'syntax-propertize-function) 'idris-syntax-propertize-function)
 
-  ; REPL completion for Idris source
-  (set (make-local-variable 'completion-at-point-functions) '(idris-complete-symbol-at-point))
+  ;; REPL completion for Idris source
+  (set (make-local-variable 'completion-at-point-functions)
+       (list 'idris-complete-symbol-at-point
+             'idris-complete-keyword-at-point))
 
   ;; imenu support
   (set (make-local-variable 'imenu-case-fold-search) nil)

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -105,7 +105,7 @@ Invokes `idris-mode-hook'."
   ; REPL completion for Idris source
   (set (make-local-variable 'completion-at-point-functions) '(idris-complete-symbol-at-point))
 
-  ; imenu support
+  ;; imenu support
   (set (make-local-variable 'imenu-case-fold-search) nil)
   (set (make-local-variable 'imenu-generic-expression)
        '(("Data" "^\\s-*data\\s-+\\(\\sw+\\)" 1)
@@ -116,12 +116,12 @@ Invokes `idris-mode-hook'."
          (nil "^\\s-*\\(\\sw+\\)\\s-*:" 1)
          ("Namespaces" "^\\s-*namespace\\s-+\\(\\sw\\|\\.\\)" 1)))
 
-  ; eldoc support
+  ;; eldoc support
   (set (make-local-variable 'eldoc-documentation-function) 'idris-eldoc-lookup)
 
-  ; Filling of comments and docs
+  ;; Filling of comments and docs
   (set (make-local-variable 'fill-paragraph-function) 'idris-fill-paragraph)
-  ; Make dirty if necessary
+  ;; Make dirty if necessary
   (add-hook (make-local-variable 'after-change-functions) 'idris-possibly-make-dirty)
   (setq mode-name `("Idris"
                     (:eval (if idris-rex-continuations "!" ""))
@@ -129,7 +129,7 @@ Invokes `idris-mode-hook'."
                     (:eval (if (idris-current-buffer-dirty-p)
                                "(Not loaded)"
                              "(Loaded)"))))
-  ; Extra hook for LIDR files (to set up extra highlighting, etc)
+  ;; Extra hook for LIDR files (to set up extra highlighting, etc)
   (when (idris-lidr-p)
     (run-hooks 'idris-mode-lidr-hook)))
 


### PR DESCRIPTION
This adds the Idris keywords to the collection of available completions.

While this isn't a huge help in normal use, where dabbrev and yasnippet are perhaps more useful, it does make company-mode and other in-buffer completion lists much nicer, and it might help users of those modes who are new to Idris learn the language.