### PR TITLE
Allow buttons to be clicked with the left mouse button

### DIFF
--- a/idris-info.el
+++ b/idris-info.el
@@ -35,6 +35,8 @@
   (let ((map (make-keymap)))
     (suppress-keymap map) ; remove the self-inserting char commands
     (define-key map (kbd "q") 'idris-info-quit)
+    ;;; Allow buttons to be clicked with the left mouse button in info buffers
+    (define-key map [follow-link] 'mouse-face)
     (cl-loop for keyer
              in '(idris-define-docs-keys
                   idris-define-general-keys

--- a/idris-metavariable-list.el
+++ b/idris-metavariable-list.el
@@ -44,6 +44,8 @@
     (define-key map (kbd "q") 'idris-metavariable-list-quit)
     (define-key map (kbd "RET") 'idris-compiler-notes-default-action-or-show-details)
     (define-key map (kbd "<mouse-2>") 'idris-compiler-notes-default-action-or-show-details/mouse)
+    ;;; Allow buttons to be clicked with the left mouse button in the metavariable list
+    (define-key map [follow-link] 'mouse-face)
     (cl-loop for keyer
              in '(idris-define-docs-keys
                   idris-define-general-keys

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -76,6 +76,8 @@
 (defvar idris-compiler-notes-mode-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "q") 'idris-notes-quit)
+    ;;; Allow buttons to be clicked with the left mouse button in the compiler notes
+    (define-key map [follow-link] 'mouse-face)
     (cl-loop for keyer
              in '(idris-define-docs-keys
                   idris-define-general-keys


### PR DESCRIPTION
Idris-mode has confused users by sticking to the old-fashioned Emacs
convention of having mouse-2 activate buttons. This enables mouse-1 for
buttons in info buffers, the metavariable list, and compiler notes.

Fixes #319.