### PR TITLE
Remove clickable imports code

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -830,7 +830,7 @@ means to not ask for confirmation."
     (define-key menu [idris-namespace-menu-browse-namespace]
       `(menu-item ,(concat "Browse " namespace)
                   (lambda () (interactive))))
-    (when (stringp file)
+    (when (and (stringp file) (file-exists-p file))
       (define-key menu [idris-namespace-menu-visit-file]
         `(menu-item ,(concat "Edit " file)
                     (lambda () (interactive)))))
@@ -1129,26 +1129,6 @@ of the term to replace."
           ;; Otherwise do nothing
           "")))))
 
-(defun idris-make-imports-clickable ()
-  "Attempt to make imports in the current package into clickable
-links in BUFFER. If BUFFER is nil, use the current buffer."
-  (interactive)
-  (idris-clear-file-link-overlays 'idris-mode)
-  (let ((ipkg-src-dir (idris-ipkg-find-src-dir)))
-    (when ipkg-src-dir
-      (save-excursion
-        (goto-char (point-min))
-        (while (re-search-forward (if (idris-lidr-p)
-                                      "^> import\\s-+\\([a-zA-Z0-9\\.]+\\)"
-                                    "^import\\s-+\\([a-zA-Z0-9\\.]+\\)") nil t)
-          (let ((start (match-beginning 1)) (end (match-end 1)))
-            (idris-make-module-link start end ipkg-src-dir)))))))
-
-(defun idris-enable-clickable-imports ()
-  "Enable the generation of clickable module imports for the current buffer"
-  (interactive)
-  (add-hook 'after-save-hook 'idris-make-imports-clickable)
-  (idris-make-imports-clickable))
 
 (defun idris-set-idris-packages ()
   "Interactively set the `idris-packages' variable"

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -125,12 +125,10 @@ behavior."
 
 ;;; Mode hooks
 (defcustom idris-mode-hook '(turn-on-idris-simple-indent
-                             idris-enable-clickable-imports
                              turn-on-eldoc-mode)
   "Hook to run upon entering Idris mode. You should choose at most one indentation style."
   :type 'hook
   :options '(turn-on-idris-simple-indent
-             idris-enable-clickable-imports
              turn-on-eldoc-mode)
   :group 'idris)
 


### PR DESCRIPTION
This is superseded by the compiler-supported annotation of imports with
their source directory, and it will now work across packages. It's
better to write Haskell code that every editor can share!