### PR TITLE
Improve default faces and discoverability of customize

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -85,6 +85,7 @@
      ["Hide error context" (idris-set-option :error-context nil)
       :visible (idris-get-option :error-context)])
     ["Customize idris-mode" (customize-group 'idris) t]
+    ["Customize fonts and colors" (customize-group 'idris-faces) t]
     ))
 
 

--- a/idris-prover.el
+++ b/idris-prover.el
@@ -38,14 +38,14 @@
 (defgroup idris-prover nil "Idris Prover" :prefix 'idris :group 'idris)
 
 (defface idris-prover-processed-face
-  '((t (:background "spring green")))
+  '((t (:background "PaleGreen1")))
   "Face for Idris proof script which is already processed."
-  :group 'idris-prover)
+  :group 'idris-faces)
 
 (defface idris-prover-processing-face
   '((t (:background "gold")))
   "Face for Idris proof script which is currently processing."
-  :group 'idris-prover)
+  :group 'idris-faces)
 
 (defcustom idris-prover-restore-window-configuration t
   "When non-nil, restore the window configuration after exiting

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -87,7 +87,7 @@
   :group 'idris-faces)
 
 (defface idris-semantic-function-face
-  '((t (:foreground "green")))
+  '((t (:foreground "darkgreen")))
   "The face to be used to highlight defined functions"
   :group 'idris-faces)
 

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -23,7 +23,15 @@
 (require 'idris-common-utils)
 (require 'cl-lib)
 
-(defgroup idris-faces nil "Idris highlighting" :prefix 'idris :group 'idris)
+(defgroup idris-faces nil
+  "Fonts and colors for Idris code.
+
+Because Idris's highlighting is semantic rather than syntactic,
+there aren't really very good defaults to appeal to from
+font-lock. You may need to change these settings to work well
+with your favorite theme. If you do so, please consider
+contributing the settings upstream to the theme maintainer."
+  :prefix 'idris :group 'idris)
 
 (defface idris-identifier-face
   '((t (:inherit default)))


### PR DESCRIPTION
We've gotten a reasonable number of complaints about the colors in
idris-mode. This attempts to make it easier for users to figure out how
to change them. It also makes the defaults a bit better for a light
theme.

Fixes #201.