### PR TITLE
Allow separate customization of Idris's doc face

### DIFF
--- a/idris-settings.el
+++ b/idris-settings.el
@@ -118,6 +118,11 @@ defaults to nothing, but is provided for users who prefer the old
 behavior."
   :group 'idris-faces)
 
+(defface idris-inline-doc-face
+  '((t :inherit font-lock-doc-face))
+  "The face shown for IdrisDoc while editing Idris files."
+  :group 'idris-faces)
+
 (defface idris-info-title-face
   '((t :inherit header-line))
   "Face for Idris headers and titles."

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -232,7 +232,7 @@ esp. `font-lock-defaults', for details."
         ;; Documentation comments.
         (,(line-start "\\s-*\\(|||\\)\\(.*\\)$")
          (1 font-lock-comment-delimiter-face)
-         (2 font-lock-doc-face))
+         (2 'idris-inline-doc-face))
         (,(line-start "\\s-*\\(|||\\)\\s-*\\(@\\)\\s-*\\(\\sw+\\)")
          (1 font-lock-comment-delimiter-face t)
          (2 font-lock-comment-delimiter-face t)


### PR DESCRIPTION
This is because the theme defaults may be good for every other mode but
get in the way of semantic highlighting faces.