### PR TITLE
Support the proof shell that uses reflected Elab

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -905,6 +905,10 @@ means to not ask for confirmation."
     (define-key menu [idris-metavariable-menu-prover]
       `(menu-item "Launch prover"
                   (lambda () (interactive))))
+    (when idris-enable-elab-prover
+      (define-key menu [idris-metavariable-menu-elab]
+        `(menu-item "Launch interactive elaborator"
+                    (lambda () (interactive)))))
     menu))
 
 (defun idris-make-metavariable-keymap (name)
@@ -914,6 +918,8 @@ means to not ask for confirmation."
         (let ((selection (x-popup-menu t (idris-make-metavariable-menu name))))
           (cond ((equal selection '(idris-metavariable-menu-prover))
                  (idris-prove-metavariable name))
+                ((equal selection '(idris-metavariable-menu-elab))
+                 (idris-prove-metavariable name t))
                 (t (message "%S" selection))))))
     map))
 
@@ -1102,9 +1108,9 @@ of the term to replace."
       (goto-char start)
       (insert new-term))))
 
-(defun idris-prove-metavariable (name)
-  "Launch the prover on the metavariable NAME."
-  (idris-eval-async `(:interpret ,(concat ":p " name))
+(defun idris-prove-metavariable (name &optional elab)
+  "Launch the prover on the metavariable NAME, using Elab mode if ELAB is non-nil."
+  (idris-eval-async `(:interpret ,(concat (if elab ":elab " ":p ") name))
                     (lambda (_) t))
   ;; The timer is necessary because of the async nature of starting the prover
   (run-with-timer 0.25 nil

--- a/idris-metavariable-list.el
+++ b/idris-metavariable-list.el
@@ -81,7 +81,9 @@ Invoces `idris-metavariable-list-mode-hook'.")
       (idris-metavariable-list-mode)
       (when idris-show-help-text
         (insert "This buffer displays the unsolved metavariables from the currently-loaded code. ")
-        (insert "Press the [P] buttons to solve the metavariables interactively in the prover.")
+        (insert (concat "Press the "
+                        (if idris-enable-elab-prover "[E]" "[P]")
+                        "buttons to solve the metavariables interactively in the prover."))
         (let ((fill-column 80))
           (fill-region (point-min) (point-max)))
         (insert "\n\n"))
@@ -115,11 +117,17 @@ METAVAR should be a three-element list consisting of the
 metavariable name, its premises, and its conclusion."
   (cl-destructuring-bind (name premises conclusion) metavar
     (make-idris-tree :item name
-                     :button `("[P]"
-                               help-echo "Open in prover"
-                               action ,#'(lambda (_)
-                                           (interactive)
-                                           (idris-prove-metavariable name)))
+                     :button (if idris-enable-elab-prover
+                                 `("[E]"
+                                   help-echo "Elaborate interactively"
+                                   action ,#'(lambda (_)
+                                               (interactive)
+                                               (idris-prove-metavariable name t)))
+                               `("[P]"
+                                 help-echo "Open in prover"
+                                 action ,#'(lambda (_)
+                                             (interactive)
+                                             (idris-prove-metavariable name))))
                      :highlighting `((0 ,(length name) ((:decor :metavar))))
                      :print-fn #'idris-metavariable-tree-printer
                      :collapsed-p (not idris-metavariable-list-show-expanded) ; from customize

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -177,6 +177,13 @@ with lots of space for the metavariable buffer."
   :type 'boolean
   :group 'idris)
 
+(defcustom idris-enable-elab-prover nil
+  "Whether or not to enable the interactive prover for elaborator reflection.
+Disabled by default until Idris 0.9.19 because it requires a
+change to ordinary prover interaction."
+  :type 'boolean
+  :group 'idris)
+
 ;;;; Other hooks
 (defcustom idris-run-hook '(idris-set-current-pretty-print-width)
   "A hook to run when Idris is started."


### PR DESCRIPTION
Idris has a new alternative proof shell that uses elaborator reflection instead of the built-in tactics. This adds support for it to `idris-mode`'s interactive prover.