### PR TITLE
Rename metavariables to holes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OBJS =	idris-commands.elc		\
 	idris-ipkg-mode.elc		\
 	idris-keys.elc			\
 	idris-log.elc			\
-	idris-metavariable-list.elc	\
+	idris-hole-list.elc		\
 	idris-mode.elc			\
 	idris-prover.elc		\
 	idris-repl.elc			\

--- a/documentation.tex
+++ b/documentation.tex
@@ -54,7 +54,7 @@ The proof mode consists of three buffers, one shows the proof obligation, anothe
 The proof script buffer highlights the processed parts of the proof script.
 There are keybindings available to step forward and backwards over the proof script, namely C-n and C-p.
 Additionally, completion of partially written proof script is supported and bound to the key tab.
-To get into proof mode, start proving a metavariable by typing \textsf{:p metavariable} at the REPL.
+To get into proof mode, start proving a hole by typing \textsf{:p hole} at the REPL.
 
 Help for the current modes is available, as usual, by C-h m.
 

--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -112,7 +112,7 @@ inserted text (that is, relative to point prior to insertion)."
 
 ;;; Take care of circular dependency issue
 (autoload 'idris-make-ref-menu-keymap "idris-commands.el")
-(autoload 'idris-make-metavariable-keymap "idris-commands.el")
+(autoload 'idris-make-hole-keymap "idris-commands.el")
 (autoload 'idris-make-error-keymap "idris-commands.el")
 (autoload 'idris-make-namespace-keymap "idris-commands.el")
 (autoload 'idris-eval "inferior-idris.el")
@@ -133,7 +133,7 @@ inserted text (that is, relative to point prior to insertion)."
                            (:data '(idris-semantic-data-face))
                            (:function '(idris-semantic-function-face))
                            (:keyword '(idris-keyword-face))
-                           (:metavar '(idris-metavariable-face))
+                           (:metavar '(idris-hole-face))
                            (:bound '(idris-semantic-bound-face))
                            (:namespace '(idris-semantic-namespace-face))
                            (:postulate '(idris-semantic-postulate-face))
@@ -218,7 +218,7 @@ inserted text (that is, relative to point prior to insertion)."
                                            nil))))
                          ((equal (cadr decor) :metavar)
                           (list 'idris-ref (cadr name)
-                                'keymap (idris-make-metavariable-keymap (cadr name))))
+                                'keymap (idris-make-hole-keymap (cadr name))))
                          (t nil)))
                   (namespace
                    (cond ((or (equal (cadr decor) :module)

--- a/idris-hole-list.el
+++ b/idris-hole-list.el
@@ -1,4 +1,4 @@
-;;; idris-metavariable-list.el --- List Idris metavariables in a buffer -*- lexical-binding: t -*-
+;;; idris-hole-list.el --- List Idris holes in a buffer -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2014 David Raymond Christiansen
 
@@ -30,21 +30,21 @@
 (require 'idris-warnings-tree)
 (require 'idris-settings)
 
-(defvar idris-metavariable-list-buffer-name (idris-buffer-name :metavariables)
-  "The name of the buffer containing Idris metavariables")
+(defvar idris-hole-list-buffer-name (idris-buffer-name :holes)
+  "The name of the buffer containing Idris holes")
 
-(defun idris-metavariable-list-quit ()
-  "Quit the Idris metavariable list"
+(defun idris-hole-list-quit ()
+  "Quit the Idris hole list"
   (interactive)
-  (idris-kill-buffer idris-metavariable-list-buffer-name))
+  (idris-kill-buffer idris-hole-list-buffer-name))
 
-(defvar idris-metavariable-list-mode-map
+(defvar idris-hole-list-mode-map
   (let ((map (make-keymap)))
     (suppress-keymap map)
-    (define-key map (kbd "q") 'idris-metavariable-list-quit)
+    (define-key map (kbd "q") 'idris-hole-list-quit)
     (define-key map (kbd "RET") 'idris-compiler-notes-default-action-or-show-details)
     (define-key map (kbd "<mouse-2>") 'idris-compiler-notes-default-action-or-show-details/mouse)
-    ;;; Allow buttons to be clicked with the left mouse button in the metavariable list
+    ;;; Allow buttons to be clicked with the left mouse button in the hole list
     (define-key map [follow-link] 'mouse-face)
     (cl-loop for keyer
              in '(idris-define-docs-keys
@@ -53,52 +53,52 @@
              do (funcall keyer map))
     map))
 
-(easy-menu-define idris-metavariable-list-mode-menu idris-metavariable-list-mode-map
-  "Menu for the Idris metavariable list buffer"
-  `("Idris Metavars"
+(easy-menu-define idris-hole-list-mode-menu idris-hole-list-mode-map
+  "Menu for the Idris hole list buffer"
+  `("Idris Holes"
     ["Show term interaction widgets" idris-add-term-widgets t]
-    ["Close metavariable list buffer" idris-metavariable-list-quit t]))
+    ["Close hole list buffer" idris-hole-list-quit t]))
 
-(define-derived-mode idris-metavariable-list-mode fundamental-mode "Idris Metavars"
-  "Major mode used for transient Idris metavariable list buffers
-   \\{idris-metavariable-list-mode-map}
-Invoces `idris-metavariable-list-mode-hook'.")
+(define-derived-mode idris-hole-list-mode fundamental-mode "Idris Holes"
+  "Major mode used for transient Idris hole list buffers
+   \\{idris-hole-list-mode-map}
+Invoces `idris-hole-list-mode-hook'.")
 
-(defun idris-metavariable-list-buffer ()
-  "Return the Idris metavariable buffer, creating one if there is not one"
-  (get-buffer-create idris-metavariable-list-buffer-name))
+(defun idris-hole-list-buffer ()
+  "Return the Idris hole buffer, creating one if there is not one"
+  (get-buffer-create idris-hole-list-buffer-name))
 
-(defun idris-metavariable-list-buffer-visible-p ()
-  (if (get-buffer-window idris-metavariable-list-buffer-name 'visible) t nil))
+(defun idris-hole-list-buffer-visible-p ()
+  (if (get-buffer-window idris-hole-list-buffer-name 'visible) t nil))
 
-(defun idris-metavariable-list-show (metavar-info)
-  (if (null metavar-info)
-      (progn (message "No metavariables found!")
-             (idris-metavariable-list-quit))
-    (with-current-buffer (idris-metavariable-list-buffer)
+(defun idris-hole-list-show (hole-info)
+  (if (null hole-info)
+      (progn (message "No holes found!")
+             (idris-hole-list-quit))
+    (with-current-buffer (idris-hole-list-buffer)
       (setq buffer-read-only nil)
       (erase-buffer)
-      (idris-metavariable-list-mode)
+      (idris-hole-list-mode)
+      (insert (propertize "Holes" 'face 'idris-info-title-face) "\n\n")
       (when idris-show-help-text
-        (insert "This buffer displays the unsolved metavariables from the currently-loaded code. ")
+        (insert "This buffer displays the unsolved holes from the currently-loaded code. ")
         (insert (concat "Press the "
                         (if idris-enable-elab-prover "[E]" "[P]")
-                        "buttons to solve the metavariables interactively in the prover."))
+                        " buttons to solve the holes interactively in the prover."))
         (let ((fill-column 80))
           (fill-region (point-min) (point-max)))
         (insert "\n\n"))
 
-      (insert (propertize "Metavariables" 'face 'idris-info-title-face) "\n")
-      (dolist (tree (mapcar #'idris-tree-for-metavariable metavar-info))
+      (dolist (tree (mapcar #'idris-tree-for-hole hole-info))
         (idris-tree-insert tree "")
         (insert "\n\n"))
       (message "Press q to close")
       (setq buffer-read-only t)
       (goto-char (point-min)))
-    (display-buffer (idris-metavariable-list-buffer))))
+    (display-buffer (idris-hole-list-buffer))))
 
-(defun idris-metavariable-tree-printer (tree)
-  "Print TREE, formatted for metavariables."
+(defun idris-hole-tree-printer (tree)
+  "Print TREE, formatted for holes."
   (idris-propertize-spans (idris-repl-semantic-text-props (idris-tree.highlighting tree))
     (insert (idris-tree.item tree)))
   (when (idris-tree.button tree)
@@ -108,32 +108,32 @@ Invoces `idris-metavariable-list-mode-hook'.")
 
 
 ;;; Prevent circularity error
-(autoload 'idris-prove-metavariable "idris-commands.el")
+(autoload 'idris-prove-hole "idris-commands.el")
 
-(defun idris-tree-for-metavariable (metavar)
-  "Generate a tree for METAVAR.
+(defun idris-tree-for-hole (hole)
+  "Generate a tree for HOLE.
 
-METAVAR should be a three-element list consisting of the
-metavariable name, its premises, and its conclusion."
-  (cl-destructuring-bind (name premises conclusion) metavar
+HOLE should be a three-element list consisting of the
+hole name, its premises, and its conclusion."
+  (cl-destructuring-bind (name premises conclusion) hole
     (make-idris-tree :item name
                      :button (if idris-enable-elab-prover
                                  `("[E]"
                                    help-echo "Elaborate interactively"
                                    action ,#'(lambda (_)
                                                (interactive)
-                                               (idris-prove-metavariable name t)))
+                                               (idris-prove-hole name t)))
                                `("[P]"
                                  help-echo "Open in prover"
                                  action ,#'(lambda (_)
                                              (interactive)
-                                             (idris-prove-metavariable name))))
+                                             (idris-prove-hole name))))
                      :highlighting `((0 ,(length name) ((:decor :metavar))))
-                     :print-fn #'idris-metavariable-tree-printer
-                     :collapsed-p (not idris-metavariable-list-show-expanded) ; from customize
-                     :kids (list (idris-tree-for-metavariable-details name premises conclusion)))))
+                     :print-fn #'idris-hole-tree-printer
+                     :collapsed-p (not idris-hole-list-show-expanded) ; from customize
+                     :kids (list (idris-tree-for-hole-details name premises conclusion)))))
 
-(defun idris-tree-for-metavariable-details (name premises conclusion)
+(defun idris-tree-for-hole-details (name premises conclusion)
   (let* ((name-width (1+ (apply #'max 0 (length name)
                                 (mapcar #'(lambda (h) (length (car h)))
                                         premises))))
@@ -172,4 +172,4 @@ metavariable name, its premises, and its conclusion."
                      :highlighting '())))
 
 
-(provide 'idris-metavariable-list)
+(provide 'idris-hole-list)

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -59,8 +59,8 @@
     ["Add missing cases" idris-add-missing t]
     ["Case split pattern variable" idris-case-split t]
     ["Add with block" idris-make-with-block t]
-    ["Extract lemma from metavariable" idris-make-lemma t]
-    ["Attempt to solve metavariable" idris-proof-search t]
+    ["Extract lemma from hole" idris-make-lemma t]
+    ["Attempt to solve hole" idris-proof-search t]
     ["Display type" idris-type-at-point t]
     "-----------------"
     ["Open package" idris-open-package-file t]

--- a/idris-prover.el
+++ b/idris-prover.el
@@ -63,8 +63,8 @@ the prover."
   "The name of the Idris proof script buffer.")
 
 (defvar idris-prover-currently-proving nil
-  "The metavariable that Idris has open in the interactive
-prover, or nil if Idris is not proving anything.")
+  "The hole that Idris has open in the interactive prover, or nil
+if Idris is not proving anything.")
 
 (defconst idris-prover-error-message-prefix "Prover error: "
   "A prefix to show on minibuffer error messages that originate
@@ -434,10 +434,10 @@ the length reported by Idris."
      t)
     (_ nil)))
 
-(defcustom idris-prover-success-hook '(idris-list-metavariables-on-load)
+(defcustom idris-prover-success-hook '(idris-list-holes-on-load)
   "Functions to call when completing a proof"
   :type 'hook
-  :options '(idris-list-metavariables-on-load)
+  :options '(idris-list-holes-on-load)
   :group 'idris-prover)
 
 (defun idris-perhaps-insert-proof-script (proof)

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -165,20 +165,20 @@ behavior."
   :options ()
   :group 'idris)
 
-(defcustom idris-metavariable-list-mode-hook ()
-  "Hook to run when setting up the list of metavariables."
+(defcustom idris-hole-list-mode-hook ()
+  "Hook to run when setting up the list of holes."
   :type 'hook
   :options ()
   :group 'idris)
 
-(defcustom idris-metavariable-show-on-load t
-  "Show the current metavariables on successful load."
+(defcustom idris-hole-show-on-load t
+  "Show the current holes on successful load."
   :type 'boolean
   :group 'idris)
 
-(defcustom idris-metavariable-list-show-expanded nil
-  "Show the metavariable list fully expanded by default. This may be useful on wide monitors
-with lots of space for the metavariable buffer."
+(defcustom idris-hole-list-show-expanded nil
+  "Show the hole list fully expanded by default. This may be useful on wide monitors
+with lots of space for the hole buffer."
   :type 'boolean
   :group 'idris)
 

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -38,9 +38,9 @@ contributing the settings upstream to the theme maintainer."
   "The face to highlight Idris identifiers with."
   :group 'idris-faces)
 
-(defface idris-metavariable-face
+(defface idris-hole-face
   '((t (:inherit idris-identifier-face)))
-  "The face to highlight Idris metavariables with."
+  "The face to highlight Idris holes with."
   :group 'idris-faces)
 
 (defface idris-keyword-face
@@ -253,8 +253,8 @@ esp. `font-lock-defaults', for details."
          (1 'idris-keyword-face))
         ;; Operators
         (,(apply-partially #'idris-font-lock-literate-search idris-operator-regexp (idris-lidr-p)) . 'idris-operator-face)
-        ;; Metavariables
-        (,(apply-partially #'idris-font-lock-literate-search "\\?[a-zA-Z_]\\w*" (idris-lidr-p)) . 'idris-metavariable-face)
+        ;; Holes
+        (,(apply-partially #'idris-font-lock-literate-search "\\?[a-zA-Z_]\\w*" (idris-lidr-p)) . 'idris-hole-face)
         ;; Identifiers
         (,(apply-partially #'idris-font-lock-literate-search "[a-zA-Z_]\\w*" (idris-lidr-p)) . 'idris-identifier-face)
         ;; Scary stuff

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -50,35 +50,35 @@ remain."
     (kill-buffer idris-event-buffer-name)))
 
 
-(ert-deftest idris-test-metavar-load ()
-  "Test the metavariable-list-on-load setting."
+(ert-deftest idris-test-hole-load ()
+  "Test the hole-list-on-load setting."
   (idris-quit)
-  ;;; The default setting should be to show metavariables
-  (should idris-metavariable-show-on-load)
+  ;;; The default setting should be to show holes
+  (should idris-hole-show-on-load)
 
   (let ((buffer (find-file "test-data/MetavarTest.idr")))
     ;;; Check that the file was loaded
     (should (bufferp buffer))
 
-    ;;; Check that it shows the metavar list with the option turned on
+    ;;; Check that it shows the hole list with the option turned on
     (with-current-buffer buffer
       (idris-load-file))
     ;;; Allow async stuff to happen
     (dotimes (_ 5) (accept-process-output nil 1))
-    (let ((mv-buffer (get-buffer idris-metavariable-list-buffer-name)))
+    (let ((mv-buffer (get-buffer idris-hole-list-buffer-name)))
       ;; The buffer exists and contains characters
       (should (bufferp mv-buffer))
       (should (> (buffer-size mv-buffer) 10)))
     (idris-quit)
 
     ;; Now check that it works with the setting the other way
-     (let ((idris-metavariable-show-on-load nil))
-       (with-current-buffer buffer
-         (idris-load-file))
-       (dotimes (_ 5) (accept-process-output nil 1))
-       (let ((mv-buffer (get-buffer idris-metavariable-list-buffer-name)))
-         (should-not (bufferp mv-buffer))
-         (should (null mv-buffer))))
+    (let ((idris-hole-show-on-load nil))
+      (with-current-buffer buffer
+        (idris-load-file))
+      (dotimes (_ 5) (accept-process-output nil 1))
+      (let ((mv-buffer (get-buffer idris-hole-list-buffer-name)))
+        (should-not (bufferp mv-buffer))
+        (should (null mv-buffer))))
     ;; Clean up
     (kill-buffer))
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -72,8 +72,8 @@ The following commands are available when there is an inferior Idris process (wh
 * `C-c C-n`, `C-c C-p`: Extend and contract the region to be loaded, if such a region exists, one line at a time.
 * `C-c C-s`: Create an initial pattern match clause for a type declaration
 * `C-c C-m`: Add missing pattern-match cases to an existing definition
-* `C-c C-a`: Attempt to solve a metavariable automatically. A plain prefix argument prompts for hints, while a numeric prefix argument sets the recursion depth.
-* `C-c C-e`: Extract a metavariable or provisional definition name to an explicit top level definition
+* `C-c C-a`: Attempt to solve a hole automatically. A plain prefix argument prompts for hints, while a numeric prefix argument sets the recursion depth.
+* `C-c C-e`: Extract a hole or provisional definition name to an explicit top level definition
 * `C-c C-c`: Case split the pattern variable under point
 * `C-c C-t`: Get the type for the identifier under point. A prefix argument prompts for the name.
 * `C-c C-w`: Add a with block for the pattern-match clause under point


### PR DESCRIPTION
This matches changes made in the Idris command-line interface. The IDE
protocol has not been modified.