### PR TITLE
Use prop-menu.el to show popups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,13 @@ script:
       - popd
 
       # emacs 24.3
+      - make getdeps
       - make build
       - make test
       - make clean
 
       # emacs 24.4
+      - make getdeps EMACS=/usr/local/emacs-24.4/bin/emacs
       - make build EMACS=/usr/local/emacs-24.4/bin/emacs
       - make test EMACS=/usr/local/emacs-24.4/bin/emacs
+      - make clean

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,6 @@ clean:
 	-rm -f test-data/*ibc
 
 getdeps:
-	$(BATCHEMACS) -eval '(package-install (quote prop-menu))'
+	$(BATCHEMACS) -eval '(progn (package-refresh-contents) (package-install (quote prop-menu)))'
 
 .PHONY: clean build test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 EMACS=emacs24
 
-BATCHEMACS=$(EMACS) --batch --no-site-file -q -eval '(add-to-list (quote load-path) "${PWD}/")' -eval '(add-to-list (quote package-archives) (quote ("melpa" . "http://melpa.org/packages/")) t)' -eval '(package-initialize)'
+BATCHEMACS=$(EMACS) --batch --no-site-file -q -eval '(add-to-list (quote load-path) "${PWD}/")' -eval '(require (quote package))' -eval '(add-to-list (quote package-archives) (quote ("melpa" . "http://melpa.org/packages/")) t)' -eval '(package-initialize)'
 
 BYTECOMP = $(BATCHEMACS) -eval '(progn (require (quote bytecomp)) (setq byte-compile-warnings t) (setq byte-compile-error-on-warn t))' -f batch-byte-compile
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 # Makefile for idris-mode, to run tests and ensure dependencies are in order
 # Portions based on the Makefile for Proof General
 
-EMACS=emacs
+EMACS=emacs24
 
-BATCHEMACS=$(EMACS) --batch --no-site-file -q -eval '(add-to-list (quote load-path) "${PWD}/")'
+BATCHEMACS=$(EMACS) --batch --no-site-file -q -eval '(add-to-list (quote load-path) "${PWD}/")' -eval '(add-to-list (quote package-archives) (quote ("melpa" . "http://melpa.org/packages/")) t)' -eval '(package-initialize)'
 
 BYTECOMP = $(BATCHEMACS) -eval '(progn (require (quote bytecomp)) (setq byte-compile-warnings t) (setq byte-compile-error-on-warn t))' -f batch-byte-compile
 
@@ -40,5 +40,8 @@ test:
 clean:
 	-rm -f $(OBJS)
 	-rm -f test-data/*ibc
+
+getdeps:
+	$(BATCHEMACS) -eval '(package-install (quote prop-menu))'
 
 .PHONY: clean build test

--- a/idris-compat.el
+++ b/idris-compat.el
@@ -1,7 +1,9 @@
 ;;; idris-compat.el --- compatibility functions for Emacs 24.1 -*- lexical-binding: t -*-
 
+;;; Commentary:
 ;; This file defines defvar-local, which was introduced in Emacs 24.3, and string-suffix-p, from Emacs 24.4.
 
+;;; Code:
 (unless (fboundp 'defvar-local)
   (defmacro defvar-local (var val &optional docstring)
     `(progn
@@ -20,3 +22,4 @@ attention to case differences."
                                   string start-pos nil ignore-case))))))
 
 (provide 'idris-compat)
+;;; idris-compat.el ends here

--- a/idris-core.el
+++ b/idris-core.el
@@ -23,11 +23,14 @@
 ;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;; Boston, MA 02111-1307, USA.
 
+;;; Code:
 (require 'idris-compat)
-(provide 'idris-core)
 
 (defun idris-is-ident-char-p (ch)
   (or (and (<= ?a ch) (<= ch ?z))
       (and (<= ?A ch) (<= ch ?Z))
       (and (<= ?0 ch) (<= ch ?9))
       (= ch ?_)))
+
+(provide 'idris-core)
+;;; idris-core.el ends here

--- a/idris-hole-list.el
+++ b/idris-hole-list.el
@@ -24,6 +24,7 @@
 ;; Boston, MA 02111-1307, USA.
 
 (require 'cl-lib)
+(require 'prop-menu)
 
 (require 'idris-core)
 (require 'idris-keys)
@@ -62,7 +63,8 @@
 (define-derived-mode idris-hole-list-mode fundamental-mode "Idris Holes"
   "Major mode used for transient Idris hole list buffers
    \\{idris-hole-list-mode-map}
-Invoces `idris-hole-list-mode-hook'.")
+Invoces `idris-hole-list-mode-hook'."
+  (setq-local prop-menu-item-functions '(idris-context-menu-items)))
 
 (defun idris-hole-list-buffer ()
   "Return the Idris hole buffer, creating one if there is not one"

--- a/idris-info.el
+++ b/idris-info.el
@@ -25,6 +25,7 @@
 ;; that buffer to a minimum.
 
 ;;; Code:
+(require 'prop-menu)
 (require 'idris-core)
 (require 'idris-common-utils)
 
@@ -89,7 +90,8 @@ Following the behavior of Emacs help buffers, the future is deleted."
 (define-derived-mode idris-info-mode fundamental-mode "Idris Info"
   "Major mode used for transient Idris information buffers
     \\{idris-info-mode-map}
-Invokes `idris-info-mode-hook'.")
+Invokes `idris-info-mode-hook'."
+  (set (make-local-variable 'prop-menu-item-functions) '(idris-context-menu-items)))
 ; if we use view-mode here, our key binding q would be shadowed.
 
 (defun idris-info-buffer ()

--- a/idris-keys.el
+++ b/idris-keys.el
@@ -69,7 +69,9 @@
 
 (defun idris-define-general-keys (map)
   "Define keys that are generally useful for all Idris modes in the keymap MAP."
-  (define-key map (kbd "C-c C-z") 'idris-pop-to-repl))
+  (define-key map (kbd "C-c C-z") 'idris-pop-to-repl)
+  (define-key map (kbd "<mouse-3>") 'prop-menu-show-menu)
+  (define-key map (kbd "C-c C-SPC") 'prop-menu-by-completing-read))
 
 (defun idris-define-active-term-keys (map)
   "Define keys for manipulating active terms in the keymap MAP."

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -17,6 +17,9 @@
 
 ;;; Code:
 
+(require 'prop-menu)
+(require 'eldoc)
+
 (require 'idris-core)
 (require 'idris-settings)
 (require 'idris-syntax)
@@ -26,8 +29,20 @@
 (require 'idris-warnings)
 (require 'idris-common-utils)
 (require 'idris-ipkg-mode)
-(require 'eldoc)
 
+
+(defun idris-mode-context-menu-items (plist)
+  "Compute menu items from PLIST that are specific to editing text in `idris-mode'."
+  (let ((ref (plist-get plist 'idris-ref))
+        (ref-style (plist-get plist 'idris-ref-style)))
+    (when (and ref (equal ref-style :metavar))
+      (list (list "Extract lemma"
+                  (let ((location (point)))
+                    (lambda ()
+                      (interactive)
+                      (save-excursion
+                        (goto-char location)
+                        (idris-make-lemma)))))))))
 
 (defvar idris-mode-map (let ((map (make-sparse-keymap)))
                          (cl-loop for keyer
@@ -134,7 +149,9 @@ Invokes `idris-mode-hook'."
                              "(Loaded)"))))
   ;; Extra hook for LIDR files (to set up extra highlighting, etc)
   (when (idris-lidr-p)
-    (run-hooks 'idris-mode-lidr-hook)))
+    (run-hooks 'idris-mode-lidr-hook))
+  (set (make-local-variable 'prop-menu-item-functions)
+       '(idris-context-menu-items idris-mode-context-menu-items)))
 
 ;; Automatically use idris-mode for .idr and .lidr files.
 ;;;###autoload

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -5,8 +5,8 @@
 ;; Author:
 ;; URL: https://github.com/idris-hackers/idris-mode
 ;; Keywords: languages
-;; Package-Requires: ((emacs "24"))
-;; Version: 0.9.14
+;; Package-Requires: ((emacs "24") (prop-menu "0.1") (cl-lib "0.5")
+;; Version: 0.9.18
 
 
 ;;; Commentary:

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -23,13 +23,18 @@
 ;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;; Boston, MA 02111-1307, USA.
 
+;;; Code:
+
+(require 'cl-lib)
+(require 'prop-menu)
+
 (require 'idris-core)
 (require 'idris-settings)
 (require 'inferior-idris)
 (require 'idris-common-utils)
 (require 'idris-prover)
 (require 'idris-highlight-input)
-(require 'cl-lib)
+
 
 (defvar idris-prompt-string "Idris"
   "The prompt shown in the REPL.")
@@ -191,7 +196,7 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
   "Major mode for interacting with Idris.
     \\{idris-repl-mode-map}
 Invokes `idris-repl-mode-hook'."
-  ;syntax-table?
+                                        ;syntax-table?
   :group 'idris-repl
   (set (make-local-variable 'indent-tabs-mode) nil)
   (add-hook 'idris-event-hooks 'idris-repl-event-hook-function)
@@ -202,7 +207,9 @@ Invokes `idris-repl-mode-hook'."
               'idris-repl-safe-save-history nil t))
   (add-hook 'kill-emacs-hook 'idris-repl-save-all-histories)
   (set (make-local-variable 'completion-at-point-functions) '(idris-repl-complete))
-  (setq mode-name `("Idris-REPL" (:eval (if idris-rex-continuations "!" "")))))
+  (setq mode-name `("Idris-REPL" (:eval (if idris-rex-continuations "!" ""))))
+  (set (make-local-variable 'prop-menu-item-functions)
+       '(idris-context-menu-items)))
 
 (defun idris-repl-remove-event-hook-function ()
   (setq idris-prompt-string "Idris")
@@ -545,3 +552,4 @@ files and this function is sufficient."
           (prin1 (mapcar #'substring-no-properties hist) (current-buffer)))))))
 
 (provide 'idris-repl)
+;;; idris-repl.el ends here

--- a/idris-tree-info.el
+++ b/idris-tree-info.el
@@ -26,6 +26,8 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'prop-menu)
+
 (require 'idris-core)
 (require 'idris-common-utils)
 (require 'idris-settings)
@@ -67,7 +69,8 @@ Invokes `idris-tree-info-mode-hook'.
 This mode should be used to display tree-structured output,
 because the history feature of `idris-info-mode' is incompatible
 with overlays and markers, which the trees need.."
-  (setq-local buffer-read-only t))
+  (setq-local buffer-read-only t)
+  (setq-local prop-menu-item-functions '(idris-context-menu-items)))
 
 (defun idris-tree-info-buffer ()
   "Return the Idris tree viewer buffer, creating one if it does not exist.

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -24,7 +24,10 @@
 ;; the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 ;; Boston, MA 02111-1307, USA.
 
+;;; Code:
 (require 'cl-lib)
+(require 'prop-menu)
+
 (require 'idris-core)
 (require 'idris-warnings)
 (require 'idris-common-utils)
@@ -99,7 +102,8 @@
 (define-derived-mode idris-compiler-notes-mode fundamental-mode "Compiler-Notes"
   "Idris compiler notes
      \\{idris-compiler-notes-mode-map}
-Invokes `idris-compiler-notes-mode-hook'.")
+Invokes `idris-compiler-notes-mode-hook'."
+  (setq-local prop-menu-item-functions '(idris-context-menu-items)))
 
 (defun idris-compiler-notes-show-details ()
   (interactive)

--- a/readme.markdown
+++ b/readme.markdown
@@ -50,6 +50,9 @@ Customize `idris-interpreter-path` if idris is not on your default path.
 * Documentation-related commands are prefixed with `C-c C-d`.
 * Commands related to **b**uilding packages are prefixed with `C-c C-b`.
 
+## Contextual menus
+`idris-mode` makes use of semantic information from the Idris compiler to display contextual menus. By default, the graphical contextual menu is bound to the right mouse button and the textual contextual menu is bound to `C-c C-SPC`. Using these commands will display commands that are available based on what is under the mouse pointer or what is at point, respectively.
+
 ## Error messages
 
 When loading a buffer, `idris-mode` will decorate errors from the Idris compiler with underlines. Tooltips show the error message.


### PR DESCRIPTION
This has a few advantages over the old way of sticking a keymap property
on regions of text:

 1. The semantic properties of the text are decoupled from the
    generation of the menus, allowing them to be different in the
    editing mode than they are in the info modes. This will eventually
    enable things like right-clicking a pattern variable to case split.

 2. Menus can take multiple kinds of information into account, merging
    e.g. the menu for an error annotation with the menu for a name
    annotation.

 3. A keyboard-accessible contextual menu is provided, bound to C-c C-SPC.