### PR TITLE
Rename idris-packages to idris-load-packages

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -1141,8 +1141,8 @@ of the term to replace."
           "")))))
 
 
-(defun idris-set-idris-packages ()
-  "Interactively set the `idris-packages' variable"
+(defun idris-set-idris-load-packages ()
+  "Interactively set the `idris-load-packages' variable"
   (interactive)
   (let* ((idris-libdir (replace-regexp-in-string
                         "[\r\n]*\\'" ""   ; remove trailing newline junk
@@ -1158,9 +1158,9 @@ of the term to replace."
                                                                idris-libs))))
     (when (y-or-n-p (format "Use the packages %s for this session?"
                             (cl-reduce #'(lambda (x y) (concat x ", " y)) packages)))
-      (setq idris-packages packages)
+      (setq idris-load-packages packages)
       (when (y-or-n-p "Save package list for future sessions? ")
-        (add-file-local-variable 'idris-packages packages)))))
+        (add-file-local-variable 'idris-load-packages packages)))))
 
 (defun idris-open-package-file ()
   "Provide easy access to package files."

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -49,7 +49,7 @@
     ["New Project" idris-start-project t]
     "-----------------"
     ["Load file" idris-load-file t]
-    ["Choose packages" idris-set-idris-packages t]
+    ["Choose packages" idris-set-idris-load-packages t]
     ["Compile and execute" idris-compile-and-execute]
     ["Delete IBC file" idris-delete-ibc t]
     ["View compiler log" idris-view-compiler-log (get-buffer idris-log-buffer-name)]

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -77,12 +77,12 @@
      (remove-hook 'idris-event-hooks 'idris-version-hook-function)
      t)))
 
-(defvar-local idris-packages nil
+(defvar-local idris-load-packages nil
   "The list of packages to be loaded by Idris. Set using file or directory variables.")
 
 (defun idris-compute-flags ()
   "Calculate the command line options to use when running Idris."
-  (append (cl-loop for p in idris-packages
+  (append (cl-loop for p in idris-load-packages
                    collecting "-p"
                    collecting p)
           idris-interpreter-flags

--- a/readme.markdown
+++ b/readme.markdown
@@ -117,9 +117,9 @@ When a package is present, `idris-mode` gains a few convenience features. In par
 Additionally, the command `M-x idris-start-project` will create a directory structure and initial package file for a new project.
 
 ## Using packages
-`idris-mode` supports setting the packages to be loaded by the Idris process. Specifically, the buffer-local variable `idris-packages` is expected to contain a list of package names to be loaded. When the buffer is loaded, if the current packages loaded by the Idris process don't agree with the contents of the variable, Idris is restarted with the correct `-p` options.
+`idris-mode` supports setting the packages to be loaded by the Idris process. Specifically, the buffer-local variable `idris-load-packages` is expected to contain a list of package names to be loaded. When the buffer is loaded, if the current packages loaded by the Idris process don't agree with the contents of the variable, Idris is restarted with the correct `-p` options.
 
-You can set this variable interactively using the command `M-x idris-set-idris-packages`. This will add the variable as a file-local variable, so that it will be set automatically when the file is loaded in the future.
+You can set this variable interactively using the command `M-x idris-set-idris-load-packages`. This will add the variable as a file-local variable, so that it will be set automatically when the file is loaded in the future.
 
 ## Installation
 


### PR DESCRIPTION
This causes idris-mode to no longer conflict with a convention in
Spacemacs, where $NAME-packages is used by convention for package
metadata. With the renamed variable, Spacemacs will be able to call it
"idris".

Fixes #373