### PR TITLE
Add compiler-supported quasiquote highlighting

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -5,3 +5,7 @@
  * The variable `idris-packages` has been renamed to
    `idris-load-packages`. If you have this as a file variable, please
    rename it.
+ * The faces `idris-quasiquotation-face` and
+   `idris-antiquotation-face` have been added, for compiler-supported
+   highlighting of quotations. They are, by default, without
+   properties, but they can be customized if desired.

--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -139,6 +139,8 @@ inserted text (that is, relative to point prior to insertion)."
          (text-format (assoc :text-formatting props))
          (idris-err (assoc :error props))
          (link-href (assoc :link-href props))
+         (qquote (assoc :quasiquotation props))
+         (aquote (assoc :antiquotation props))
          (decor-face (if decor
                          (pcase (cadr decor)
                            (:type '(idris-semantic-type-face))
@@ -176,11 +178,15 @@ inserted text (that is, relative to point prior to insertion)."
                 (link-href
                  '(highlight))
                 (t nil)))
+         (qquote-face (when qquote '(idris-quasiquotation-face)))
+         (aquote-face (when aquote '(idris-antiquotation-face)))
          (computed-face (append text-face
                                 implicit-face
                                 decor-face
                                 err-face
-                                link-face)))
+                                link-face
+                                qquote-face
+                                aquote-face)))
     (append (if computed-face (list 'face computed-face) ())
             (if mousable-face (list 'mouse-face mousable-face) ()))))
 

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -2,7 +2,7 @@
 
 ;; Copyright (C) 2013 Hannes Mehnert and David Raymond Christiansen
 
-;; Author: Hannes Mehnert <hannes@mehnert.org>
+;; Author: Hannes Mehnert <hannes@mehnert.org> and David Raymond Christiansen <david@davidchristiansen.dk>
 
 ;; License:
 ;; Inspiration is taken from SLIME/DIME (http://common-lisp.net/project/slime/) (https://github.com/dylan-lang/dylan-mode)
@@ -114,6 +114,14 @@
 (defface idris-semantic-module-face
   '((t :inherit idris-semantic-namespace-face))
   "The face to be used to highlight namespace declarations"
+  :group 'idris-faces)
+
+(defface idris-quasiquotation-face nil
+  "The face to be used to highlight quasiquotations in Idris source code"
+  :group 'idris-faces)
+
+(defface idris-antiquotation-face nil
+  "The face to be used to highlight antiquotations in Idris source code"
   :group 'idris-faces)
 
 (defface idris-loaded-region-face nil


### PR DESCRIPTION
This is editor support for Idris's parser highlights of quasiquotations
and antiquotations. This is initially disabled to avoid having too noisy
highlighting, but can be enabled as needed.

Idris PR: https://github.com/idris-lang/Idris-dev/pull/2428