### PR TITLE
Minor hole list UI improvements

### DIFF
--- a/idris-hole-list.el
+++ b/idris-hole-list.el
@@ -58,7 +58,10 @@
   "Menu for the Idris hole list buffer"
   `("Idris Holes"
     ["Show term interaction widgets" idris-add-term-widgets t]
-    ["Close hole list buffer" idris-hole-list-quit t]))
+    ["Close hole list buffer" idris-hole-list-quit t]
+    "------------------"
+    ["Customize idris-hole-list-mode" (customize-group 'idris-hole-list) t]
+    ["Customize fonts and colors" (customize-group 'idris-faces) t]))
 
 (define-derived-mode idris-hole-list-mode fundamental-mode "Idris Holes"
   "Major mode used for transient Idris hole list buffers

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -181,7 +181,7 @@ behavior."
   :type 'boolean
   :group 'idris)
 
-(defcustom idris-hole-list-show-expanded nil
+(defcustom idris-hole-list-show-expanded t
   "Show the hole list fully expanded by default. This may be useful on wide monitors
 with lots of space for the hole buffer."
   :type 'boolean

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -170,11 +170,15 @@ behavior."
   :options ()
   :group 'idris)
 
+(defgroup idris-hole-list nil
+  "Options related to the Idris hole list buffer."
+  :group 'idris)
+
 (defcustom idris-hole-list-mode-hook ()
   "Hook to run when setting up the list of holes."
   :type 'hook
   :options ()
-  :group 'idris)
+  :group 'idris-hole-list)
 
 (defcustom idris-hole-show-on-load t
   "Show the current holes on successful load."
@@ -185,7 +189,7 @@ behavior."
   "Show the hole list fully expanded by default. This may be useful on wide monitors
 with lots of space for the hole buffer."
   :type 'boolean
-  :group 'idris)
+  :group 'idris-hole-list)
 
 (defcustom idris-enable-elab-prover nil
   "Whether or not to enable the interactive prover for elaborator reflection.


### PR DESCRIPTION
Now the hole contexts are show expanded by default (but users can still turn it off). This is based on feedback from real users, including @jasonhemann. Additionally, because I had forgotten that option myself, I added a customize group for the hole list as well as links to it from the hole list menu.