### PR TITLE
Add setting for showing the REPL at Idris startup

### DIFF
--- a/idris-repl.el
+++ b/idris-repl.el
@@ -138,7 +138,8 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
   (or (get-buffer idris-repl-buffer-name)
       (let ((buffer (get-buffer-create idris-repl-buffer-name)))
         (save-selected-window
-          (pop-to-buffer buffer t)
+          (when idris-repl-show-repl-on-startup
+            (pop-to-buffer buffer t))
           (with-current-buffer buffer
             (idris-repl-mode)
             (idris-repl-buffer-init))

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -279,4 +279,9 @@ Set to `nil' for no banner."
   :type 'symbol
   :group 'idris-repl)
 
+(defcustom idris-repl-show-repl-on-startup t
+  "If non-`nil', show the REPL window when Idris starts. If `nil', only do this when `idris-repl' was called interactively."
+  :type 'boolean
+  :group 'idris-repl)
+
 (provide 'idris-settings)


### PR DESCRIPTION
The new customize option idris-repl-show-repl-on-startup controls
whether the REPL becomes visible at startup. If non-nil (the default),
then the REPL is always shown when it comes into existence. If nil, the
REPL is only shown when explicitly requested with M-x idris-repl or C-c
C-z (idris-pop-to-repl).

Fixes #380.