### PR TITLE
Add support for new Idris command :make-case

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -559,6 +559,26 @@ KILLFLAG is set if N was explicitly specified."
           (delete-region (line-beginning-position) (line-end-position))
           (insert (substring result 0 (1- (length result)))))))))
 
+(defun idris-make-cases-from-hole ()
+  "Make a case expression from the metavariable at point."
+  (interactive)
+  (let ((what (idris-thing-at-point)))
+    (when (car what)
+      (save-excursion (idris-load-file-sync))
+      (let ((result (car (idris-eval `(:make-case ,(cdr what) ,(car what))))))
+        (if (<= (length result) 2)
+            (message "Can't make cases from %s" (car what))
+          (delete-region (line-beginning-position) (line-end-position))
+          (insert (substring result 0 (1- (length result)))))))))
+
+(defun idris-case-dwim ()
+  "If point is on a hole name, make it into a case expression. Otherwise, case split as a pattern variable."
+  (interactive)
+  (if (or (looking-at-p "\\?[a-zA-Z]+")
+          (looking-back "\\?[a-zA-Z0-9]+"))
+      (idris-make-cases-from-hole)
+    (idris-case-split)))
+
 (defun idris-add-clause (proof)
   "Add clauses to the declaration at point"
   (interactive "P")

--- a/idris-keys.el
+++ b/idris-keys.el
@@ -53,7 +53,7 @@
 
 (defun idris-define-editing-keys (map)
   "Define the keys related to editing Idris code in the keymap MAP."
-  (define-key map (kbd "C-c C-c") 'idris-case-split)
+  (define-key map (kbd "C-c C-c") 'idris-case-dwim)
   (define-key map (kbd "C-c C-m") 'idris-add-missing)
   (define-key map (kbd "C-c C-e") 'idris-make-lemma)
   (define-key map (kbd "C-c C-s") 'idris-add-clause)

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -42,7 +42,14 @@
                       (interactive)
                       (save-excursion
                         (goto-char location)
-                        (idris-make-lemma)))))))))
+                        (idris-make-lemma)))))
+            (list "Fill with case block"
+                  (let ((location (point)))
+                    (lambda ()
+                      (interactive)
+                      (save-excursion
+                        (goto-char location)
+                        (idris-make-cases-from-hole)))))))))
 
 (defvar idris-mode-map (let ((map (make-sparse-keymap)))
                          (cl-loop for keyer
@@ -75,6 +82,7 @@
     ["Case split pattern variable" idris-case-split t]
     ["Add with block" idris-make-with-block t]
     ["Extract lemma from hole" idris-make-lemma t]
+    ["Solve hole with case expression" idris-make-cases-from-hole t]
     ["Attempt to solve hole" idris-proof-search t]
     ["Display type" idris-type-at-point t]
     "-----------------"
@@ -99,8 +107,7 @@
      ["Hide error context" (idris-set-option :error-context nil)
       :visible (idris-get-option :error-context)])
     ["Customize idris-mode" (customize-group 'idris) t]
-    ["Customize fonts and colors" (customize-group 'idris-faces) t]
-    ))
+    ["Customize fonts and colors" (customize-group 'idris-faces) t]))
 
 
 ;;;###autoload

--- a/readme.markdown
+++ b/readme.markdown
@@ -82,7 +82,7 @@ The following commands are available when there is an inferior Idris process (wh
 * `C-c C-m`: Add missing pattern-match cases to an existing definition
 * `C-c C-a`: Attempt to solve a hole automatically. A plain prefix argument prompts for hints, while a numeric prefix argument sets the recursion depth.
 * `C-c C-e`: Extract a hole or provisional definition name to an explicit top level definition
-* `C-c C-c`: Case split the pattern variable under point
+* `C-c C-c`: Case split the pattern variable under point, or fill the hole at point with a case expression.
 * `C-c C-t`: Get the type for the identifier under point. A prefix argument prompts for the name.
 * `C-c C-w`: Add a with block for the pattern-match clause under point
 * `C-c C-h a`: Search names, types, and docstrings for a given string.


### PR DESCRIPTION
This command allows the generation of case blocks in holes. The mode is
set up to use the same keybinding to case-split a pattern variable or a
hole, to avoid needing to learn more bindings. Additionally, the context
menus for holes have been updated.

This requires an up-to-date Idris, but the only regression on an old
Idris is that the case-split command will give a more confusing error
message when run on a hole.