### PR TITLE
Add namespace annotation to source

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -233,8 +233,10 @@ inserted text (that is, relative to point prior to insertion)."
                    (if (and (member (cadr decor)
                                     '(:type :data :function :metavar))
                             name)
-                       (list 'idris-ref (cadr name)
-                             'idris-ref-style (cadr decor))
+                       (append (list 'idris-ref (cadr name)
+                                     'idris-ref-style (cadr decor))
+                               (when namespace
+                                 (list 'idris-namespace (cadr namespace))))
                      ()))
                   (namespace
                    (if (or (equal (cadr decor) :module)


### PR DESCRIPTION
Now, the namespace of global names is added to source code spans. This
enables a "Browse namespace" option in their contextual menu, which is
very convenient when exploring a library.