### PR TITLE
Insert a newline after a proof script

### DIFF
--- a/idris-prover.el
+++ b/idris-prover.el
@@ -467,8 +467,9 @@ the length reported by Idris."
       (goto-char (point-min))
       (unless (re-search-forward idris-proof-script-insertion-marker nil t)
         (when (re-search-forward "\\(\\s-*\n\\)*\\'")
-              (replace-match (concat "\n\n" idris-proof-script-insertion-marker "\n") nil nil)))
+          (replace-match (concat "\n\n" idris-proof-script-insertion-marker "\n") nil nil)))
       (newline)
-      (insert proof))))
+      (insert proof)
+      (newline))))
 
 (provide 'idris-prover)


### PR DESCRIPTION
This can avoid irritation when dealing with narrowed buffers.