### PR TITLE
Use annotations for Eldoc instead of compiler

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -522,12 +522,7 @@ KILLFLAG is set if N was explicitly specified."
 
 (defun idris-eldoc-lookup ()
   "Support for showing type signatures in the modeline when there's a running Idris"
-  (let ((signature (ignore-errors (idris-eval (list :type-of (idris-name-at-point)) t))))
-    (when signature
-      (with-temp-buffer
-        (idris-propertize-spans (idris-repl-semantic-text-props (cdr signature))
-          (insert (car signature)))
-        (buffer-string)))))
+  (get-char-property (point) 'idris-eldoc))
 
 (defun idris-pretty-print ()
   "Get a term or definition pretty-printed by Idris. Useful for writing papers or slides."

--- a/readme.markdown
+++ b/readme.markdown
@@ -95,6 +95,8 @@ The Idris compiler supports documentation. The following commands access it:
 * `C-c C-d a`: Search the documentation for a string (`:apropos` at the REPL).
 * `C-c C-d t`: Search for documentation regarding a particular type (`:search` at the REPL).
 
+Additionally, `idris-mode` integrates with `eldoc-mode`, which shows documentation overviews and type signatures in the minibuffer.
+
 ## Completion
 
 `M-Tab` or whatever you have `completion-at-point` bound to will ask the running Idris process for completions for the current identifier. Note that this command requires that the Idris interpreter is already running, because attempting to load an incomplete buffer would probably not work.


### PR DESCRIPTION
Now, when the compiler annotates source files, the Eldoc strings are
pre-computed. This makes Eldoc lookup instantaneous, and allows it to
work when the compiler is busy doing other things. It also makes the
docstring tooltips of annotated buffers useful in terminal Emacs, by
exposing this information in another way.

Finally, even names that can't be referenced (e.g. the contents of where
blocks) now get eldoc support.

Fixes #251 by not round-tripping to the compiler.

Fixes #279 the same way.