### PR TITLE
Make ipkg commands use idris-interpreter-path

### DIFF
--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -228,7 +228,7 @@ arguments."
     (let* ((default-directory dir) ; default-directory is a special variable - this starts idris in dir
            (compilation-buffer-name-function
             'idris-ipkg--compilation-buffer-name-function)
-           (command (concat "idris " opt " " file))
+           (command (concat idris-interpreter-path " " opt " " file))
            (compilation-filter-hook
             (cons 'idris-ipkg--ansi-compile-filter compilation-filter-hook)))
       (compile command))))


### PR DESCRIPTION
This makes them also work when idris is not on the path, or when the
user wants to use a specific one.

Fixes #403.