### PR TITLE
Check port is number in Idris process filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OBJS =	idris-commands.elc		\
 build: $(OBJS)
 
 test:
-	$(BATCHEMACS) -l ert -l idris-tests.el -f ert-run-tests-batch-and-exit
+	$(BATCHEMACS) -L . -l ert -l idris-tests.el -f ert-run-tests-batch-and-exit
 
 clean:
 	-rm -f $(OBJS)

--- a/idris-compat.el
+++ b/idris-compat.el
@@ -4,6 +4,15 @@
 ;; This file defines defvar-local, which was introduced in Emacs 24.3, and string-suffix-p, from Emacs 24.4.
 
 ;;; Code:
+(require 'subr-x nil 'no-error)   ; Additional utilities, Emacs 24.4 and upwards
+
+(eval-and-compile
+  (unless (featurep 'subr-x)
+    ;; `subr-x' function for Emacs 24.3 and below
+    (defsubst string-blank-p (string)
+      "Check whether STRING is either empty or only whitespace."
+      (string-match-p "\\`[ \t\n\r]*\\'" string))))
+
 (unless (fboundp 'defvar-local)
   (defmacro defvar-local (var val &optional docstring)
     `(progn

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -151,6 +151,7 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
   (pop-to-buffer (idris-repl-buffer))
   (goto-char (point-max)))
 
+;;;###autoload
 (defun idris-repl ()
   (interactive)
   (idris-run)

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'idris-mode)
+(require 'inferior-idris)
 (require 'idris-ipkg-mode)
 (require 'cl-lib)
 
@@ -32,6 +33,15 @@
 (ert-deftest trivial-test ()
   (should t))
 
+(ert-deftest idris-test-idris-editor-port ()
+  (let ((output "Can't find import Prelude\n37072\n"))
+    (should (string-match idris-process-port-output-regexp output))
+    (should (string= "Can't find import Prelude\n" (match-string 1 output)))
+    (should (string= "37072" (match-string 2 output))))
+  (let ((output "37072\n"))
+    (should (string-match idris-process-port-output-regexp output))
+    (should (null (match-string 1 output)))
+    (should (string= "37072" (match-string 2 output)))))
 
 (ert-deftest idris-test-idris-quit ()
   "Ensure that running Idris and quitting doesn't leave behind


### PR DESCRIPTION
Somethimes the idris command send warnings like `Can't find import Prelude` and `idris-process-filter` uses `string-to-number` which fails and returns `0` (zero) as port.
 
Related: #334