### PR TITLE
Fix void-function error in idris-settings.el

### DIFF
--- a/idris-settings.el
+++ b/idris-settings.el
@@ -224,6 +224,8 @@ change to ordinary prover interaction."
   :group 'idris)
 
 ;;;; Other hooks
+
+(autoload 'idris-set-current-pretty-print-width "idris-commands.el")
 (defcustom idris-run-hook '(idris-set-current-pretty-print-width)
   "A hook to run when Idris is started."
   :type 'hook


### PR DESCRIPTION
idris-settings.el referred to `idris-set-current-pretty-print-width` without ensuring it was bound, which would cause a void-function error when running `idris-repl` prior to having visited an idris-mode buffer. Fixed by adding an autoload to idris-settings.el.