### PR TITLE
Give operator chars "." syntax and improve idris-thing-at-point

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -309,15 +309,22 @@ Idris process. This sets the load position to point, if there is one."
 
 
 (defun idris-thing-at-point ()
-  "Return the line number and name at point. Use this in Idris source buffers."
-  (let ((name (thing-at-point 'word))
-        (op (thing-at-point 'symbol))
-        (line (idris-get-line-num)))
-    (if name
-        (cons (substring-no-properties name) line)
-      (if op
-          (cons (substring-no-properties op) line)
-        (error "Nothing identifiable under point")))))
+  "Return the line number and name at point as a cons.
+Use this in Idris source buffers."
+  (let ((line (idris-get-line-num)))
+    (cons
+     (if (equal (syntax-after (point))
+                (string-to-syntax "."))
+         ;; We're on an operator.
+         (save-excursion
+           (skip-syntax-backward ".")
+           (let ((beg (point)))
+             (skip-syntax-forward ".")
+             (buffer-substring-no-properties beg (point))))
+       ;; Try if we're on a symbol or fail otherwise.
+       (or (current-word t)
+           (error "Nothing identifiable under point")))
+     line)))
 
 (defun idris-name-at-point ()
   "Return the name at point, taking into account semantic

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -121,17 +121,18 @@ contributing the settings upstream to the theme maintainer."
     ;; Matching {}, but with nested comments
     (modify-syntax-entry ?\{ "(} 1bn" st)
     (modify-syntax-entry ?\} "){ 4bn" st)
-    (modify-syntax-entry ?\- "_ 123" st)
     (modify-syntax-entry ?\n ">" st)
 
-    ;; ' and _ can be names
-    (modify-syntax-entry ?' "w" st)
-    (modify-syntax-entry ?_ "w" st)
+    ;; ' and _ can be part of names, so give them symbol constituent syntax
+    (modify-syntax-entry ?' "_" st)
+    (modify-syntax-entry ?_ "_" st)
 
-
-    ;; Idris operator chars
-    (mapc #'(lambda (ch) (modify-syntax-entry ch "_" st))
-          "!#$%&*+./<=>@^|~:")
+    ;; Idris operator chars get punctuation syntax
+    (mapc #'(lambda (ch) (modify-syntax-entry ch "." st))
+	  "!#$%&*+./<=>@^|~:")
+    ;; - is an operator char but may also be 1st or 2nd char of comment starter
+    ;; -- and the 1st char of comment end -}
+    (modify-syntax-entry ?\- ". 123" st)
 
     ;; Whitespace is whitespace
     (modify-syntax-entry ?\  " " st)


### PR DESCRIPTION
- idris-syntax.el (idris-syntax-table): Give operator characters
  punctuation syntax like other modes do, too.  Also fix problems with
  comment syntax of - (-- comments were not highlighted as such, and now
  they are).
- idris-commands.el (idris-thing-at-point): Rewrite to use current-word
  instead of thing-at-point.  The latter is movement-based, the former
  is syntax-based.  Now idris-thing-at-point works for symbols and also
  for operators.

The problems were caught my eyes as part of #433 where I noticed that
things like case split didn't work for camelCase functions when Emacs
subword-mode is enabled.
