### PR TITLE
Fix byte-compile warning about deprecated feature

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -227,7 +227,7 @@ line."
                                                        start-line start-col
                                                        end-line end-col
                                                        props))))))
-               (t (idris-make-clean)
+               (_ (idris-make-clean)
                   (idris-update-options-cache)
 
                   (setq idris-currently-loaded-buffer (current-buffer))
@@ -426,7 +426,7 @@ compiler-annotated output. Does not return a line number."
                                  nil)))
                          children))
       :preserve-properties '(idris-tt-tree)))
-    (t (error "failed to make tree from %s" caller))))
+    (_ (error "failed to make tree from %s" caller))))
 
 (defun idris-namespace-tree (namespace &optional recursive)
   "Create a tree of the contents of NAMESPACE, lazily retrieving children when RECURSIVE is non-nil."
@@ -469,7 +469,7 @@ compiler-annotated output. Does not return a line number."
             :collapsed-p nil
             :kids (get-children sub-namespaces names)
             :preserve-properties '(idris-tt-term)))
-          (t (error "Invalid namespace %s" namespace)))))))
+          (_ (error "Invalid namespace %s" namespace)))))))
 
 (defun idris-newline-and-indent ()
   "Indent a new line like the current one by default"

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -350,7 +350,7 @@ Invokes `idris-repl-mode-hook'."
                  ,props)
                (idris-repl-highlight-input
                 start start-line start-col end-line end-col props))))))
-       (t (idris-repl-insert-result result spans)))) ;; The actual result
+       (_ (idris-repl-insert-result result spans)))) ;; The actual result
     ((:error condition &optional spans)
      (idris-repl-show-abort condition spans))))
 

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -406,7 +406,7 @@ applicable. Returns nil if the version of Idris used doesn't
 support asking for versions."
   (pcase (idris-eval :version t)
     (`((,version ,prerelease)) (cons version prerelease))
-    (t nil)))
+    (_ nil)))
 
 (defun idris-get-idris-version-string ()
   "Ask the Idris compiler for its version information, and return the result as a user-friendly string.


### PR DESCRIPTION
Anything match in pcase should use '_' instead of 't'.

```
inferior-idris.el:408:46:Warning: Pattern t is deprecated.  Use `_' instead
```