### PR TITLE
Fix hole name regexp in idris-case-dwim

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -594,8 +594,8 @@ KILLFLAG is set if N was explicitly specified."
 (defun idris-case-dwim ()
   "If point is on a hole name, make it into a case expression. Otherwise, case split as a pattern variable."
   (interactive)
-  (if (or (looking-at-p "\\?[a-zA-Z]+")
-          (looking-back "\\?[a-zA-Z0-9]+"))
+  (if (or (looking-at-p "\\?[a-zA-Z_]+")
+          (looking-back "\\?[a-zA-Z0-9_]+"))
       (idris-make-cases-from-hole)
     (idris-case-split)))
 


### PR DESCRIPTION
@halfaya saw that case splitting on holes worked unpredicably. It turns out it was holes with underscores that threw it off.