### PR TITLE
Replace 't' case with '_' to silence warning

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -456,7 +456,7 @@ compiler-annotated output. Does not return a line number."
                    (pcase (idris-eval `(:browse-namespace ,namespace))
                      (`((,sub-namespaces ,names . ,_))
                       (get-children sub-namespaces names))
-                     (t nil)))
+                     (_ nil)))
            :preserve-properties '(idris-tt-term))
         ;; In the non-recursive case, generate an expanded tree with the
         ;; first level available, but only if the namespace actually makes


### PR DESCRIPTION
In Emacs 25, `pcase` `t` patterns result in this warning:

```
Pattern t is deprecated. Use ‘_’ instead
```

This PR removes such a pattern.

Thanks for maintaining idris-mode!