### PR TITLE
Require cl, fixing some byte compilation warnings.

### DIFF
--- a/idris-prover.el
+++ b/idris-prover.el
@@ -28,6 +28,8 @@
 (require 'idris-settings)
 (require 'inferior-idris)
 
+(eval-when-compile (require 'cl))
+
 ; consisting of three buffers:
 ; ------------------------------
 ; | proof obligations          |

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -35,6 +35,8 @@
 (require 'idris-prover)
 (require 'idris-highlight-input)
 
+(eval-when-compile (require 'cl))
+
 
 (defvar idris-prompt-string "Idris"
   "The prompt shown in the REPL.")


### PR DESCRIPTION
Specifically: this appears to fix "Warning: `:ok' called as a
function" and similar warnings on emacs 24.5.1.

I am still not familiar with some elisp features, and am not certain
why requiring the cl package fixes the warnings alleging that various
keyword symbols, and `t`, are called as functions.  So there could
easily a different change that would be better, like a modification to
the `idris-rex` function, or somehow getting `inferior-idris.el` to
run its `eval-when-compile` statements when it is required by a file
getting compiled.

It might be a good idea to upgrade to cl-lib.