### PR TITLE
Prevent completion-error when identifier is at beginning of buffer

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -764,22 +764,18 @@ prefix argument sets the recursion depth directly."
         (insert result)))))
 
 (defun idris-identifier-backwards-from-point ()
-  (let ((identifier-start nil)
+  (let (identifier-start
         (identifier-end (point))
-        (last-char (char-before))
         (failure (list nil nil nil)))
-    (if (idris-is-ident-char-p last-char)
-        (progn
-          (save-excursion
-            (while (idris-is-ident-char-p (char-before))
-              (backward-char))
-            (setq identifier-start (point)))
-          (if identifier-start
-              (list (buffer-substring-no-properties identifier-start identifier-end)
-                    identifier-start
-                    identifier-end)
-            failure))
-      failure)))
+    (save-excursion
+      (while (and (> (point) (point-min)) (idris-is-ident-char-p (char-before)))
+        (backward-char)
+        (setq identifier-start (point)))
+      (if identifier-start
+          (list (buffer-substring-no-properties identifier-start identifier-end)
+                identifier-start
+                identifier-end)
+        failure))))
 
 (defun idris-complete-symbol-at-point ()
   "Attempt to complete the symbol at point as a global variable.


### PR DESCRIPTION
When using `company-capf`  after typing first char in buffer:

```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p nil)
  idris-is-ident-char-p(nil)
  idris-identifier-backwards-from-point()
  idris-complete-keyword-at-point()
  completion--capf-wrapper(idris-complete-keyword-at-point optimist)
  run-hook-wrapped(completion--capf-wrapper idris-complete-keyword-at-point optimist)
  company--capf-data-real()
...
```
 