### PR TITLE
Add emacs 26.1 to travis matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
     - env: EMACS_VERSION=24.3
     - env: EMACS_VERSION=24.4
     - env: EMACS_VERSION=25.3
+    - env: EMACS_VERSION=26.1
 
 # Caching so the next build will be fast too.
 cache:


### PR DESCRIPTION
Now that 26.1 is the current emacs release, might as well test it.