### PR TITLE
Allow underscores in ipkg package names

### DIFF
--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -333,7 +333,7 @@ arguments."
         (let ((pkgs nil))
           (cl-flet
               ((get-pkg ()
-                        (re-search-forward "[a-zA-Z0-9\\.]+" nil t)
+                        (re-search-forward "[a-zA-Z0-9\\._-]+" nil t)
                         (let ((beg (match-beginning 0))
                               (end (match-end 0)))
                           (push (buffer-substring-no-properties beg end) pkgs))))

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -157,5 +157,14 @@ remain."
       (kill-buffer))
     (idris-quit)))
 
+(ert-deftest idris-test-ipkg-packages-with-underscores-and-dashes ()
+  "Test that loading an ipkg file can have dependencies on packages with _ or - in the name."
+  (let ((buffer (find-file "test-data/package-test/Packaging.idr")))
+    (with-current-buffer buffer
+      (should (equal '("-p" "idris-free" "-p" "recursion_schemes")
+                     (idris-ipkg-pkgs-flags-for-current-buffer)))
+      (kill-buffer buffer))
+    (idris-quit)))
+
 (provide 'idris-tests)
 ;;; idris-tests.el ends here

--- a/test-data/package-test/Packaging.idr
+++ b/test-data/package-test/Packaging.idr
@@ -1,0 +1,2 @@
+module Packaging
+

--- a/test-data/package-test/test.ipkg
+++ b/test-data/package-test/test.ipkg
@@ -1,0 +1,3 @@
+package test
+
+pkgs = recursion_schemes, idris-free


### PR DESCRIPTION
I looked at the docs and packages are allowed to be named like "any valid idris identifier" (http://docs.idris-lang.org/en/latest/reference/packages.html). Does that mean the packages allowed should be expanded further?

May close #460