### PR TITLE
match only .ipkg extension

### DIFF
--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -171,7 +171,7 @@ or nil if not found."
       ((find-file-r (path)
                     (let* ((parent (file-name-directory path))
                            (matching (if parent
-                                         (idris-try-directory-files parent t (concat suffix "$"))
+                                         (idris-try-directory-files parent t (concat "\\\." suffix "$"))
                                        nil)))
                       (cond
                        (matching matching)


### PR DESCRIPTION
Current implementation matches all the names which ends with "ipkg", including inappropriate names  like "example-multipkg".
This patch changes to match only ipkg extensions.

```
ELISP> (string-match (concat "\\\." "ipkg" "$") "mypkg.ipkg")
5 (#o5, #x5, ?\C-e)
ELISP> (string-match (concat "\\\." "ipkg" "$") "ipkg")
nil
ELISP> (string-match (concat "\\\." "ipkg" "$") "multipkg")
nil
```
