### PR TITLE
Bug-fix issue #402: flag buffer dirty on load-file to line and forward/backward-line

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -155,6 +155,7 @@
     (save-excursion
       (goto-char idris-load-to-here)
       (forward-line nlines)
+      (idris-make-dirty)
       (idris-load-to (point)))))
 
 (defun idris-load-backward-line ()
@@ -176,12 +177,13 @@
 
 (defun idris-load-file (&optional set-line)
   "Pass the current buffer's file to the inferior Idris process.
-A prefix argument restricts loading to the current
-line."
+A prefix argument forces loading but only up to the current line."
   (interactive "p")
   (save-buffer)
   (idris-ensure-process-and-repl-buffer)
-  (when (and set-line (= set-line 4)) (idris-load-to (point)))
+  (when (and set-line (= set-line 4))
+    (idris-load-to (point))
+    (idris-make-dirty))
   (when (and set-line (= set-line 16)) (idris-no-load-to))
   (if (buffer-file-name)
       (when (idris-current-buffer-dirty-p)


### PR DESCRIPTION
When stepping through an unchanged file, the user wants to force
buffer reload, even if it's not been changed