### PR TITLE
Support the Idris 2 proof-search-next IDE protocol command

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -747,7 +747,9 @@ prefix argument sets the recursion depth directly."
         (what (idris-thing-at-point)))
     (when (car what)
       (save-excursion (idris-load-file-sync))
-      (let ((result (car (idris-eval `(:proof-search ,(cdr what) ,(car what) ,hints ,@depth)))))
+      ;; With Idris 2, using hints or depth in idris-eval produces errors in the process filter.
+      ;; Since both are optional, remove them here until someone is able to debug the root cause.
+      (let ((result (car (idris-eval `(:proof-search ,(cdr what) ,(car what))))))
         (if (string= result "")
             (error "Nothing found")
           (save-excursion

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -723,6 +723,11 @@ KILLFLAG is set if N was explicitly specified."
   (idris-load-file-sync)
   (idris-eval '(:interpret ":exec")))
 
+(defvar-local proof-region-start nil
+  "The start position of the last proof region.")
+(defvar-local proof-region-end nil
+  "The end position of the last proof region.")
+
 (defun idris-proof-search (&optional arg)
   "Invoke the proof search. A plain prefix argument causes the
 command to prompt for hints and recursion depth, while a numeric
@@ -749,7 +754,24 @@ prefix argument sets the recursion depth directly."
             (let ((start (progn (search-backward "?") (point)))
                   (end (progn (forward-char) (search-forward-regexp "[^a-zA-Z0-9_']") (backward-char) (point))))
               (delete-region start end))
-            (insert result)))))))
+	    (setq proof-region-start (point))
+	    (insert result)
+	    (setq proof-region-end (point))))))))
+
+(defun idris-proof-search-next ()
+  "Replace the previous proof search result with the next one, if it exists.  Idris 2 only."
+  (interactive)
+  (if (not proof-region-start)
+      (error "You must proof search first before looking for subsequent proof results.")
+    (let ((result (car (idris-eval `:proof-search-next))))
+      (if (string= result "No more results")
+          (message "No more results")
+	(save-excursion
+	  (goto-char proof-region-start)
+	  (delete-region proof-region-start proof-region-end)
+	  (setq proof-region-start (point))
+          (insert result)
+	  (setq proof-region-end (point)))))))
 
 (defun idris-refine (name)
   "Refine by some NAME, without recursive proof search."

--- a/idris-keys.el
+++ b/idris-keys.el
@@ -59,6 +59,7 @@
   (define-key map (kbd "C-c C-s") 'idris-add-clause)
   (define-key map (kbd "C-c C-w") 'idris-make-with-block)
   (define-key map (kbd "C-c C-a") 'idris-proof-search)
+  (define-key map (kbd "C-c C-S-a") 'idris-proof-search-next)
   (define-key map (kbd "C-c C-r") 'idris-refine)
   (define-key map (kbd "RET") 'idris-newline-and-indent)
   ;; Not using `kbd' due to oddness about backspace and delete

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -84,6 +84,7 @@
     ["Extract lemma from hole" idris-make-lemma t]
     ["Solve hole with case expression" idris-make-cases-from-hole t]
     ["Attempt to solve hole" idris-proof-search t]
+    ["Get next solve attempt (Idris 2)" idris-proof-search-next t]
     ["Display type" idris-type-at-point t]
     "-----------------"
     ["Open package" idris-open-package-file t]

--- a/readme.markdown
+++ b/readme.markdown
@@ -81,6 +81,7 @@ The following commands are available when there is an inferior Idris process (wh
 * `C-c C-s`: Create an initial pattern match clause for a type declaration
 * `C-c C-m`: Add missing pattern-match cases to an existing definition
 * `C-c C-a`: Attempt to solve a hole automatically. A plain prefix argument prompts for hints, while a numeric prefix argument sets the recursion depth.
+* `C-c C-S-a`: (Idris 2 only) Replace the previous proof search answer with a different attempt by the compiler.  If no further attempts are available it leaves the last one unchanged.
 * `C-c C-e`: Extract a hole or provisional definition name to an explicit top level definition
 * `C-c C-c`: Case split the pattern variable under point, or fill the hole at point with a case expression.
 * `C-c C-t`: Get the type for the identifier under point. A prefix argument prompts for the name.


### PR DESCRIPTION
Idris 2 provides a new protocol command (proof-search-next) to iterate through multiple attempts to solve a hole.   This was raised in issue #510 .

The first commit in this branch adds support for the new command.  The second commit works around issue #509 which stops the basic `proof-search` command from working in Idris 2.  It will still work in Idris 1 but without the optional arguments functionality.

The code passes the tests if the unused variables left over from the 509 fix above are taken out but given that is only a workaround you might prefer if they were left in?