### PR TITLE
Fix the last character of the response being omitted when case-splitting

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -579,7 +579,7 @@ KILLFLAG is set if N was explicitly specified."
         (if (<= (length result) 2)
             (message "Can't case split %s" (car what))
           (delete-region (line-beginning-position) (line-end-position))
-          (insert (substring result 0 (1- (length result)))))))))
+          (insert (substring result 0 (length result))))))))
 
 (defun idris-make-cases-from-hole ()
   "Make a case expression from the metavariable at point."
@@ -591,7 +591,7 @@ KILLFLAG is set if N was explicitly specified."
         (if (<= (length result) 2)
             (message "Can't make cases from %s" (car what))
           (delete-region (line-beginning-position) (line-end-position))
-          (insert (substring result 0 (1- (length result)))))))))
+          (insert (substring result 0 (length result))))))))
 
 (defun idris-case-dwim ()
   "If point is on a hole name, make it into a case expression. Otherwise, case split as a pattern variable."


### PR DESCRIPTION
…or making a case expression from a hole with Idris 2.  Fixes issue #512.

As the issue says, this leaves an extra newline at the end of the inserted response in Idris 1.  It's still valid but slightly annoying.  We may need to look at adding a setting to indicate Idris 1 vs 2 and tweak some of these functions but that needs a separate discussion.