### PR TITLE
Support Idris 2 IDE commands generate-def and generate-def-next

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -751,6 +751,36 @@ prefix argument sets the recursion depth directly."
               (delete-region start end))
             (insert result)))))))
 
+(defun idris-generate-def ()
+  "Generate defintion."
+  (interactive)
+  (let ((what (idris-thing-at-point)))
+    (when (car what)
+      (save-excursion (idris-load-file-sync))
+      (let ((result (car (idris-eval `(:generate-def ,(cdr what) ,(car what))))))
+        (if (string= result "")
+            (error "Nothing found")
+          (save-excursion
+	    (forward-line 1)
+	    (setq def-region-start (point))
+	    (insert result)
+	    (setq def-region-end (point))))))))
+
+(defun idris-generate-def-next ()
+  "Replace the previous generated definition with next definition, if it exists.  Idris 2 only."
+  (interactive)
+  (if (not def-region-start)
+      (error "You must program search first before looking for subsequent program results.")
+    (let ((result (car (idris-eval `:generate-def-next))))
+      (if (string= result "No more results")
+          (message "No more results")
+	(save-excursion
+	  (goto-char def-region-start)
+	  (delete-region def-region-start def-region-end)
+	  (setq def-region-start (point))
+          (insert result)
+	  (setq def-region-end (point)))))))
+
 (defun idris-refine (name)
   "Refine by some NAME, without recursive proof search."
   (interactive "MRefine by: ")

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -751,6 +751,9 @@ prefix argument sets the recursion depth directly."
               (delete-region start end))
             (insert result)))))))
 
+(defvar-local def-region-start nil)
+(defvar-local def-region-end nil)
+
 (defun idris-generate-def ()
   "Generate defintion."
   (interactive)

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -761,10 +761,10 @@ prefix argument sets the recursion depth directly."
         (if (string= result "")
             (error "Nothing found")
           (save-excursion
-	    (forward-line 1)
-	    (setq def-region-start (point))
-	    (insert result)
-	    (setq def-region-end (point))))))))
+            (forward-line 1)
+            (setq def-region-start (point))
+            (insert result)
+            (setq def-region-end (point))))))))
 
 (defun idris-generate-def-next ()
   "Replace the previous generated definition with next definition, if it exists.  Idris 2 only."
@@ -774,12 +774,12 @@ prefix argument sets the recursion depth directly."
     (let ((result (car (idris-eval `:generate-def-next))))
       (if (string= result "No more results")
           (message "No more results")
-	(save-excursion
-	  (goto-char def-region-start)
-	  (delete-region def-region-start def-region-end)
-	  (setq def-region-start (point))
+        (save-excursion
+          (goto-char def-region-start)
+          (delete-region def-region-start def-region-end)
+          (setq def-region-start (point))
           (insert result)
-	  (setq def-region-end (point)))))))
+          (setq def-region-end (point)))))))
 
 (defun idris-refine (name)
   "Refine by some NAME, without recursive proof search."

--- a/idris-keys.el
+++ b/idris-keys.el
@@ -59,6 +59,8 @@
   (define-key map (kbd "C-c C-s") 'idris-add-clause)
   (define-key map (kbd "C-c C-w") 'idris-make-with-block)
   (define-key map (kbd "C-c C-a") 'idris-proof-search)
+  (define-key map (kbd "C-c C-g") 'idris-generate-def)
+  (define-key map (kbd "C-c C-S-g") 'idris-generate-def-next)
   (define-key map (kbd "C-c C-r") 'idris-refine)
   (define-key map (kbd "RET") 'idris-newline-and-indent)
   ;; Not using `kbd' due to oddness about backspace and delete

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -84,6 +84,8 @@
     ["Extract lemma from hole" idris-make-lemma t]
     ["Solve hole with case expression" idris-make-cases-from-hole t]
     ["Attempt to solve hole" idris-proof-search t]
+    ["Generate definition (Idris 2)" idris-generate-def t]
+    ["Get next definition (Idris 2)" idris-generate-def-next t]
     ["Display type" idris-type-at-point t]
     "-----------------"
     ["Open package" idris-open-package-file t]


### PR DESCRIPTION
Idris2 has two new IDE commands generate-def and generate-def-next.