### PR TITLE
Added suppor for Idris IDE Protocol Versioning.

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -203,7 +203,13 @@ A prefix argument forces loading but only up to the current line."
         ;; Actually do the loading
         (let* ((dir-and-fn (idris-filename-to-load))
                (fn (cdr dir-and-fn))
-               (srcdir (car dir-and-fn)))
+               (srcdir
+                (if (> idris-version-ide-protocol 0)
+                    (prin1-to-string (car dir-and-fn))
+                    (car dir-and-fn)
+                 )
+                )
+               )
           (setq idris-currently-loaded-buffer nil)
           (idris-switch-working-directory srcdir)
           (idris-delete-ibc t) ;; delete the ibc to avoid interfering with partial loads


### PR DESCRIPTION
When connecting to a running idris process we enquire what the ide protocol being used is, and use this to differention between protocol versioning.

We show one example that should work for recent changes in how to load files.