### PR TITLE
Ci caching idris1

### DIFF
--- a/.github/workflows/idris1.yml
+++ b/.github/workflows/idris1.yml
@@ -18,7 +18,6 @@ jobs:
 # ---- [ Initialise Build Environment ]
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 2
       matrix:
         emacs: [24.5, 25.3, 26.1]
         idris: [git, stackage]
@@ -77,6 +76,7 @@ jobs:
 
 
       - name: Cache idris-dev-git/
+        if: matrix.idris == 'git'
         id: idris-dev-git
         uses: actions/cache@v2
         with:

--- a/.github/workflows/idris1.yml
+++ b/.github/workflows/idris1.yml
@@ -12,7 +12,51 @@ on:
       - main
 
 jobs:
-  build:
+
+# --- [ Caching Idris1 builds ]
+
+  caching-idris-git:
+    runs-on: ubuntu-latest
+    steps:
+
+# ---- [ Setup up cache ]
+      - name: Build Idris from Git and Save
+        id: idris-git-cache
+        uses: actions/cache@v2
+        with:
+          key: idris-git
+          path:
+            ~/.local/bin/idris
+            ~/.stack
+            ~/.stack-work
+            ~/idris-dev-git
+
+# ---- [ Install ]
+      - name: Install Idris from GIT
+        run: |
+          pushd .
+          git clone https://github.com/idris-lang/Idris-dev.git ~/idris-dev-git
+          cd ~/idris-dev-git
+          stack --no-terminal --install-ghc install --flag idris:-FFI --flag idris:-GMP
+          popd
+          idris --info
+
+# ---- [ Upload ]
+      - name: Upload Idris Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: idris-git
+          path:
+            ~/.local/bin/idris
+            ~/.stack
+            ~/.stack-work
+            ~/idris-dev-git
+
+# --- [ Testing ]
+  testing:
+
+# ---- [ Initialise Build Environment ]
+    needs: [caching-idris-git]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -22,34 +66,45 @@ jobs:
       EMACS_VERSION: ${{ matrix.emacs }}
       IDRIS_VERSION: ${{ matrix.idris }}
 
+# ---- [ Steps to Run ]
     steps:
+
+# ----- [ Steps Dependencies ]
       - name: Fetch Dependencies
         run: sudo apt install -y libgc-dev libgif-dev libxaw7-dev openssl
 
-      - name: Fetch Stack
-        run: |
-          mkdir -p ~/.local/bin
-          export PATH=$HOME/.local/bin:$PATH
-          curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+#      - name: Fetch Stack
+#        run: |
+#          mkdir -p ~/.local/bin
+#          export PATH=$HOME/.local/bin:$PATH
+#          curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+# ----- [ Emacs ]
 
       - name: Fetch Emacs
         uses: purcell/setup-emacs@master
         with:
           version: ${{ matrix.emacs }}
 
+# ----- [ Idris from GIT ]
       - name: Install Idris from GIT
         if: matrix.idris == 'git'
-        run: |
-          pushd .
-          git clone https://github.com/idris-lang/Idris-dev.git /tmp/Idris-dev
-          cd /tmp/Idris-dev
-          stack --no-terminal --install-ghc install --flag idris:-FFI --flag idris:-GMP
-          popd
+        uses: actions/download-artifact@v2
+        with:
+          name: idris-git
+          path:
+             ~/.local/bin/idris
+             ~/.stack
+             ~/.stack-work
+             ~/idris-dev-git
+
+# ----- [ Idris from Stack ]
       - name: Install Idris from Stackage
         if: matrix.idris == 'stackage'
         run: |
           stack install --resolver lts-12.26 idris
 
+# ----- [ Checkout and Run]
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -58,3 +113,5 @@ jobs:
           make clean
           make build
           make test
+
+# - EOF

--- a/.github/workflows/idris1.yml
+++ b/.github/workflows/idris1.yml
@@ -12,51 +12,10 @@ on:
       - main
 
 jobs:
-
-# --- [ Caching Idris1 builds ]
-
-  caching-idris-git:
-    runs-on: ubuntu-latest
-    steps:
-
-# ---- [ Setup up cache ]
-      - name: Build Idris from Git and Save
-        id: idris-git-cache
-        uses: actions/cache@v2
-        with:
-          key: idris-git
-          path:
-            ~/.local/bin/idris
-            ~/.stack
-            ~/.stack-work
-            ~/idris-dev-git
-
-# ---- [ Install ]
-      - name: Install Idris from GIT
-        run: |
-          pushd .
-          git clone https://github.com/idris-lang/Idris-dev.git ~/idris-dev-git
-          cd ~/idris-dev-git
-          stack --no-terminal --install-ghc install --flag idris:-FFI --flag idris:-GMP
-          popd
-          idris --info
-
-# ---- [ Upload ]
-      - name: Upload Idris Artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: idris-git
-          path:
-            ~/.local/bin/idris
-            ~/.stack
-            ~/.stack-work
-            ~/idris-dev-git
-
-# --- [ Testing ]
-  testing:
+# -- [ Build ]
+  build:
 
 # ---- [ Initialise Build Environment ]
-    needs: [caching-idris-git]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -73,11 +32,12 @@ jobs:
       - name: Fetch Dependencies
         run: sudo apt install -y libgc-dev libgif-dev libxaw7-dev openssl
 
-#      - name: Fetch Stack
-#        run: |
-#          mkdir -p ~/.local/bin
-#          export PATH=$HOME/.local/bin:$PATH
-#          curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+# ----- [ Initialise Variables ]
+
+      - name: Initialise variables
+        run: |
+          mkdir -p $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
 # ----- [ Emacs ]
 
@@ -86,17 +46,56 @@ jobs:
         with:
           version: ${{ matrix.emacs }}
 
+# ----- [ Caches ]
+
+      - name: Cache stack global package-db
+        id: stack-global
+        uses: actions/cache@v2
+        with:
+          path: ~/.stack
+          key: ${{ runner.os }}-stack-global-${{ matrix.idris }}
+          restore-keys: |
+            ${{ runner.os }}-stack-global-${{ matrix.idris }}
+            ${{ runner.os }}-stack-global-
+
+      - name: Cache stack-installed programs in ~/.local/bin
+        id:   stack-programs
+        uses: actions/cache@v2
+        with:
+          path: ~/.local/bin
+          key: ${{ runner.os }}-stack-programs-${{ matrix.idris }}
+          restore-keys: |
+               ${{ runner.os }}-stack-programs-${{ matrix.idris }}
+               ${{ runner.os }}-stack-programs-
+
+      - name: Cache .stack-work
+        uses: actions/cache@v2
+        with:
+          path: .stack-work
+          key: ${{ runner.os }}-stack-work-${{ matrix.idris }}
+          restore-keys: |
+               ${{ runner.os }}-stack-work-${{ matrix.idris }}
+               ${{ runner.os }}-stack-work-
+
+
+      - name: Cache idris-dev-git/.stack-work
+        uses: actions/cache@v2
+        with:
+          path: ~/idris-dev-git/.stack-work
+          key: ${{ runner.os }}-idris-dev-stack-work-${{ matrix.idris }}
+          restore-keys: |
+               ${{ runner.os }}-idris-dev-stack-work-${{ matrix.idris }}
+
 # ----- [ Idris from GIT ]
       - name: Install Idris from GIT
         if: matrix.idris == 'git'
-        uses: actions/download-artifact@v2
-        with:
-          name: idris-git
-          path:
-             ~/.local/bin/idris
-             ~/.stack
-             ~/.stack-work
-             ~/idris-dev-git
+        run: |
+          pushd .
+          git clone https://github.com/idris-lang/Idris-dev.git ~/idris-dev-git
+          cd ~/idris-dev-git
+          stack --no-terminal install --flag idris:-FFI --flag idris:-GMP
+          popd
+          idris --info
 
 # ----- [ Idris from Stack ]
       - name: Install Idris from Stackage

--- a/.github/workflows/idris1.yml
+++ b/.github/workflows/idris1.yml
@@ -18,6 +18,7 @@ jobs:
 # ---- [ Initialise Build Environment ]
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 2
       matrix:
         emacs: [24.5, 25.3, 26.1]
         idris: [git, stackage]
@@ -56,7 +57,6 @@ jobs:
           key: ${{ runner.os }}-stack-global-${{ matrix.idris }}
           restore-keys: |
             ${{ runner.os }}-stack-global-${{ matrix.idris }}
-            ${{ runner.os }}-stack-global-
 
       - name: Cache stack-installed programs in ~/.local/bin
         id:   stack-programs
@@ -66,7 +66,6 @@ jobs:
           key: ${{ runner.os }}-stack-programs-${{ matrix.idris }}
           restore-keys: |
                ${{ runner.os }}-stack-programs-${{ matrix.idris }}
-               ${{ runner.os }}-stack-programs-
 
       - name: Cache .stack-work
         uses: actions/cache@v2
@@ -75,20 +74,20 @@ jobs:
           key: ${{ runner.os }}-stack-work-${{ matrix.idris }}
           restore-keys: |
                ${{ runner.os }}-stack-work-${{ matrix.idris }}
-               ${{ runner.os }}-stack-work-
 
 
-      - name: Cache idris-dev-git/.stack-work
+      - name: Cache idris-dev-git/
+        id: idris-dev-git
         uses: actions/cache@v2
         with:
-          path: ~/idris-dev-git/.stack-work
+          path: ~/idris-dev-git/
           key: ${{ runner.os }}-idris-dev-stack-work-${{ matrix.idris }}
           restore-keys: |
                ${{ runner.os }}-idris-dev-stack-work-${{ matrix.idris }}
 
 # ----- [ Idris from GIT ]
       - name: Install Idris from GIT
-        if: matrix.idris == 'git'
+        if: matrix.idris == 'git' && steps.idris-dev-git.outputs.cache-hit != 'true'
         run: |
           pushd .
           git clone https://github.com/idris-lang/Idris-dev.git ~/idris-dev-git
@@ -99,7 +98,7 @@ jobs:
 
 # ----- [ Idris from Stack ]
       - name: Install Idris from Stackage
-        if: matrix.idris == 'stackage'
+        if: matrix.idris == 'stackage' && steps.stack-program.outputs.cache-hit != 'true'
         run: |
           stack install --resolver lts-12.26 idris
 
@@ -113,4 +112,4 @@ jobs:
           make build
           make test
 
-# - EOF
+# -- EOF


### PR DESCRIPTION
This *should* add the ability to cache between workflows, as outlined [here](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows). However, we do not check for cache hits explicitly, as the cache action does so. That being said, I am not sure how much speed up is attained because the caches are not finalised until after each run, and each run is launched simultaneously. Maybe there is caching between each run of the workflow...