### PR TITLE
Fix tests compile errors due to doc strings being longer than 80 chars.

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -166,7 +166,8 @@
   (idris-load-forward-line -1))
 
 (defun idris-filename-to-load ()
-  "Compute the working directory and filename to load in Idris, returning these as a cons."
+  "Compute the working directory and filename to load in Idris.
+Returning these as a cons."
   (let* ((fn (buffer-file-name))
          (ipkg-srcdir (idris-ipkg-find-src-dir))
          (srcdir (if ipkg-srcdir
@@ -267,7 +268,7 @@ A prefix argument forces loading but only up to the current line."
     (error "Cannot find file for current buffer")))
 
 (defun idris-view-compiler-log ()
-  "Jump to the log buffer, if it is open"
+  "Jump to the log buffer, if it is open."
   (interactive)
   (let ((buffer (get-buffer idris-log-buffer-name)))
     (if buffer
@@ -452,7 +453,8 @@ compiler-annotated output. Does not return a line number."
     (_ (error "failed to make tree from %s" caller))))
 
 (defun idris-namespace-tree (namespace &optional recursive)
-  "Create a tree of the contents of NAMESPACE, lazily retrieving children when RECURSIVE is non-nil."
+  "Create a tree of the contents of NAMESPACE.
+Lazily retrieve children when RECURSIVE is non-nil."
   (cl-flet*
       ;; Show names as childless trees with decorated roots
       ((name-tree (n) (make-idris-tree :item (car n)
@@ -543,17 +545,18 @@ KILLFLAG is set if N was explicitly specified."
     (t (delete-char 1 killflag))))
 
 (defun idris-apropos (what)
-  "Look up something in names, type signatures, and docstrings"
-  (interactive "sSearch Idris docs for: ")
+  "Look up WHAT in names, type signatures, and docstrings"
+  (interactive "Search Idris docs for: ")
   (idris-info-for-name :apropos what))
 
 (defun idris-type-search (what)
-  "Search the Idris libraries by fuzzy type matching"
-  (interactive "sSearch for type: ")
+  "Search the Idris libraries for WHAT by fuzzy type matching"
+  (interactive "Search for type: ")
   (idris-info-for-name :interpret (concat ":search " what)))
 
 (defun idris-docs-at-point (thing)
-  "Display the internal documentation for the name at point, considered as a global variable"
+  "Display the internal documentation for the THING (name at point).
+Considered as a global variable"
   (interactive "P")
   (let ((name (if thing (read-string "Docs: ")
                 (idris-name-at-point))))
@@ -565,7 +568,8 @@ KILLFLAG is set if N was explicitly specified."
   (get-char-property (point) 'idris-eldoc))
 
 (defun idris-pretty-print ()
-  "Get a term or definition pretty-printed by Idris. Useful for writing papers or slides."
+  "Get a term or definition pretty-printed by Idris.
+Useful for writing papers or slides."
   (interactive)
   (let ((what (read-string "What should be pretty-printed? "))
         (fmt (completing-read "What format? " '("html", "latex") nil t nil nil "latex"))
@@ -621,7 +625,8 @@ KILLFLAG is set if N was explicitly specified."
               ))))))
 
 (defun idris-case-dwim ()
-  "If point is on a hole name, make it into a case expression. Otherwise, case split as a pattern variable."
+  "If point is on a hole name, make it into a case expression.
+Otherwise, case split as a pattern variable."
   (interactive)
   (if (or (looking-at-p "\\?[a-zA-Z_]+")
           (looking-back "\\?[a-zA-Z0-9_]+" nil))
@@ -790,7 +795,8 @@ prefix argument sets the recursion depth directly."
             (setq proof-region-end (point))))))))
 
 (defun idris-proof-search-next ()
-  "Replace the previous proof search result with the next one, if it exists.  Idris 2 only."
+  "Replace the previous proof search result with the next one, if it exists.
+Idris 2 only."
   (interactive)
   (if (not proof-region-start)
       (error "You must proof search first before looking for subsequent proof results.")
@@ -847,7 +853,8 @@ prefix argument sets the recursion depth directly."
           )))))
 
 (defun idris-generate-def-next ()
-  "Replace the previous generated definition with next definition, if it exists.  Idris 2 only."
+  "Replace the previous generated definition with next definition, if it exists.
+Idris 2 only."
   (interactive)
   (if (not def-region-start)
       (error "You must program search first before looking for subsequent program results.")
@@ -943,7 +950,7 @@ type-correct, so loading will fail."
       (error "No Idris REPL buffer is open."))))
 
 (defun idris-quit ()
-  "Quit the Idris process, cleaning up the state that it has synchronized with Emacs."
+  "Quit the Idris process, cleaning up the state synchronized with Emacs."
   (interactive)
   (setq idris-prover-currently-proving nil)
   (let* ((pbufname (idris-buffer-name :process))
@@ -1014,7 +1021,8 @@ be Idris's own serialization of the term in question."
     menu))
 
 (defun idris-insert-term-widget (term)
-  "Make a widget for interacting with the term represented by TERM beginning at START-POS in the current buffer."
+  "Make a widget for interacting with the term represented by TERM
+beginning at START-POS in the current buffer."
   (let ((inhibit-read-only t)
         (start-pos (copy-marker (point)))
         (end-pos (copy-marker (idris-find-term-end (point) 1)))

--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -360,8 +360,8 @@ corresponding values in the CDR of VALUE."
              `((t (error "ELISP destructure-case failed: %S" ,tmp))))))))
 
 (defun idris-lidr-p (&optional buffer)
-  "Return t if BUFFER is a literate Idris file, or nil otherwise. Use the current buffer if
-BUFFER is not supplied or is nil."
+  "Return t if BUFFER is a literate Idris file, or nil otherwise.
+Use the current buffer if BUFFER is not supplied or is nil."
   (let ((file-name (buffer-file-name buffer)))
     ;; We check for nil here because idris-lidr-p might be called on
     ;; buffers that don't have associated files, such as the REPL

--- a/idris-highlight-input.el
+++ b/idris-highlight-input.el
@@ -29,7 +29,8 @@
 (require 'idris-settings)
 
 (defun idris-highlight-remove-overlays (&optional buffer)
-  "Remove all Idris highlighting overlays from BUFFER, or the current buffer if it's nil."
+  "Remove all Idris highlighting overlays from BUFFER.
+Use the current buffer if BUFFER is nil."
   (interactive)
   (with-current-buffer (or buffer (current-buffer))
     (save-restriction
@@ -39,7 +40,7 @@
           (delete-overlay overlay))))))
 
 (defun idris-highlight-column (idris-col)
-  "Compute the Emacs position offset of the Idris column IDRIS-COL, for highlighting.
+  "Compute the Emacs position offset of the Idris column IDRIS-COL.
 
 In particular, this takes bird tracks into account in literate Idris."
   (+ idris-col (if (idris-lidr-p) 1 -1)))
@@ -54,7 +55,8 @@ See Info node `(elisp)Overlay Properties' to understand how ARGS are used."
       (delete-overlay overlay))))
 
 (defun idris-highlight-input-region (buffer start-line start-col end-line end-col highlight)
-  "Highlight in BUFFER using an overlay from START-LINE and START-COL to END-LINE and END-COL and the semantic properties specified in HIGHLIGHT."
+  "Highlight in BUFFER using an overlay from START-LINE and START-COL to
+ END-LINE and END-COL and the semantic properties specified in HIGHLIGHT."
   (when idris-semantic-source-highlighting
     (save-restriction
       (widen)

--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -375,7 +375,8 @@ arguments."
           pkgs)))))
 
 (defun idris-ipkg-pkgs-flags-for-current-buffer ()
-  "Compute a list of Idris command line options based on the pkgs field of the .ipkg file."
+  "Compute a list of Idris command line options
+based on the pkgs field of the .ipkg file."
   (let ((pkgs (idris-ipkg-pkgs-for-current-buffer)))
     (cl-loop for pkg in pkgs appending (list "-p" pkg))))
 

--- a/idris-prover.el
+++ b/idris-prover.el
@@ -381,7 +381,7 @@ the length reported by Idris."
       (error "No proof in progress"))))
 
 (defun idris-prover-end ()
-  "Get rid of left over buffers from proof mode and unset global state related to the prover."
+  "Remove buffers from proof mode and unset global state related to the prover."
   (interactive)
   (setq idris-prover-currently-proving nil)
   (let ((obligations (idris-prover-obligations-buffer))

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -315,7 +315,9 @@ Invokes `idris-repl-mode-hook'."
   (buffer-substring-no-properties idris-input-start (point-max)))
 
 (defun idris-repl-highlight-input (start-pos start-line start-col end-line end-col props)
-  "Apply semantic highlighting to the REPL input beginning at START-POS using the Idris location information START-LINE, START-COL, END-LINE, and END-COL and semantic annotations PROPS."
+  "Apply semantic highlighting to the REPL input beginning at START-POS using
+the Idris location information START-LINE, START-COL, END-LINE, and END-COL
+and semantic annotations PROPS."
   (let ((buffer (get-buffer (idris-buffer-name :repl))))
     (with-current-buffer buffer
       (save-restriction
@@ -385,7 +387,7 @@ Invokes `idris-repl-mode-hook'."
 
 
 (defun idris-repl-insert-result (string &optional highlighting)
-  "Insert STRING and mark it asg evaluation result.
+  "Insert STRING and mark it as evaluation result.
 Optional argument HIGHLIGHTING is a collection of semantic
 highlighting information from Idris."
   (with-current-buffer (idris-repl-buffer)

--- a/idris-simple-indent.el
+++ b/idris-simple-indent.el
@@ -76,7 +76,8 @@
            idris-simple-indent-version))
 
 (defun idris-simple-indent-current-indentation ()
-  "Return the indentation of the current line, taking into account literate Idris syntax"
+  "Return the indentation of the current line.
+Takes into account literate Idris syntax."
   (save-excursion
     (move-to-column 0)
     (looking-at (if (idris-lidr-p) ">\\s-*" "\\s-*"))

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -129,7 +129,7 @@ contributing the settings upstream to the theme maintainer."
 
     ;; Idris operator chars get punctuation syntax
     (mapc #'(lambda (ch) (modify-syntax-entry ch "." st))
-	  "!#$%&*+./<=>@^|~:")
+    "!#$%&*+./<=>@^|~:")
     ;; - is an operator char but may also be 1st or 2nd char of comment starter
     ;; -- and the 1st char of comment end -}
     (modify-syntax-entry ?\- ". 123" st)
@@ -201,7 +201,8 @@ syntax table won't support, such as characters."
   "A regexp for matching Idris keywords")
 
 (defun idris-font-lock-literate-search (regexp lidr limit)
-  "Find REGEXP in Idris source between point and LIMIT, where LIDR is non-nil for literate files..
+  "Find REGEXP in Idris source between point and LIMIT.
+LIDR is non-nil for literate files.
 
 See the documentation for search-based fontification,
 esp. `font-lock-defaults', for details."

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -232,7 +232,8 @@ a preview and offer to widen."
       (insert " "))))
 
 (defun idris-tree-indent-item (start end prefix &optional preserve-props)
-  "Insert PREFIX at the beginning of each but the first line between START and END, copying the text properties in PRESERVE-PROPS.
+  "Insert PREFIX at the beginning of each but the first line
+between START and END, copying the text properties in PRESERVE-PROPS.
 This is used for labels spanning multiple lines."
   (save-excursion
     (goto-char end)

--- a/idris-warnings.el
+++ b/idris-warnings.el
@@ -77,9 +77,10 @@
 (defun idris-warning-overlay (warning)
   "Add a compiler warning to the buffer as an overlay.
 May merge overlays, if there's already one in the same location.
-WARNING is of form (filename (startline startcolumn) (endline endcolumn) message &optional highlighting-spans).
-As of 20140807 (Idris 0.9.14.1-git:abee538) (endline endcolumn) is mostly the same as (startline startcolumn)
-"
+WARNING is of form (filename (startline startcolumn) (endline endcolumn)
+message &optional highlighting-spans).
+As of 20140807 (Idris 0.9.14.1-git:abee538) (endline endcolumn)
+is mostly the same as (startline startcolumn)"
   (cl-destructuring-bind (filename sl1 sl2 message spans) warning
     (let ((startline (if (>=-protocol-version 2 1)
                          (1+ (nth 0 sl1))

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -328,7 +328,8 @@ versions cannot deal with that."
         idris-connection))))
 
 (defun idris-eval-async (sexp cont &optional failure-cont)
-  "Evaluate EXPR on the superior Idris and call CONT with the result, or FAILURE-CONT in failure case."
+  "Evaluate EXPR on the superior Idris and call CONT with the result,
+or FAILURE-CONT in failure case."
   (idris-rex (cont (buffer (current-buffer)) failure-cont)
       sexp t
     ((:ok result)
@@ -421,17 +422,16 @@ Idris error."
 (defun idris-get-idris-version ()
   "Ask the Idris compiler for its version information.
 Returns a cons cell whose car is a list of version number
-components and whose cdr is a list of prerelease identifiers, if
-applicable. Returns nil if the version of Idris used doesn't
-support asking for versions."
+components and whose cdr is a list of prerelease identifiers, if applicable.
+Returns nil if the version of Idris used doesn't support asking for versions."
   (pcase (idris-eval :version t)
     (`((,version ,prerelease)) (cons version prerelease))
     (_ nil)))
 
 (defun idris-get-idris-version-string ()
-  "Ask the Idris compiler for its version information, and return the result as a user-friendly string.
-Returns nil if the version of Idris used doesn't support asking
-for versions."
+  "Ask the Idris compiler for its version information.
+Returns result as a user-friendly string.
+Returns nil if the version of Idris used doesn't support asking for versions."
   (let ((version (idris-get-idris-version)))
     (if (consp version) ; returns nil on older versions of Idris
         (let* ((version-number (car version))


### PR DESCRIPTION
Currently `make test` results on my machine in:
```
idris-commands.el:*:*: Error:  docstring wider than 80 characters
```

Emacs version:
GNU Emacs 28.2
(build 2, x86_64-pc-linux-gnu, GTK+ Version 3.24.20, cairo version 1.16.0)

Where possible took the liberty also address warnings from Flymake not causing errors:
```
First line is not a complete sentence
Argument ‘x’ should appear (as X) in the doc string
```
Also fixes small typos in idris-repl.el (asg -> as) and in idris-commands.el (sSearch -> Search)