### PR TITLE
Kill Idris buffer and it's window if it was the only buffer in windows history.

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -73,7 +73,11 @@ Lisp package.")
               ((bufferp buffer)
                buffer)
               (t (message "don't know how to kill buffer")))))
-    (when (and buf (buffer-live-p buf)) (kill-buffer buf))))
+    (when (and buf (buffer-live-p buf))
+      (let ((win (get-buffer-window buf)))
+        (kill-buffer buf)
+        (when (null (window-prev-buffers win))
+          (delete-window win))))))
 
 (defun idris-minibuffer-respecting-message (text &rest args)
   "Display TEXT as a message, without hiding any minibuffer contents."


### PR DESCRIPTION
Previously if we killed an Idris buffer Emacs would preserve the window and copy another visible buffer into it
 which leads to not good user experience.

Before:

https://user-images.githubusercontent.com/578608/200187212-2e017540-dc0e-4c9f-9182-632980fb2cae.mp4

After:


https://user-images.githubusercontent.com/578608/200187226-d668e38c-0b70-4dbe-9841-bc8dc0e37302.mp4


