### PR TITLE
Add ability to quickly switch from Idris repl to

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -960,11 +960,12 @@ Inspired by `cider-switch-to-last-clojure-buffer'
 https://github.com/clojure-emacs/cider"
   (interactive)
   (if (derived-mode-p 'idris-repl-mode)
-      (if-let* ((a-buf (seq-find
-                        (lambda (b) (eq 'idris-mode (buffer-local-value 'major-mode b)))
-                        (buffer-list))))
-          (pop-to-buffer a-buf `(display-buffer-reuse-window))
-        (user-error "No Idris buffer found"))
+      (let ((idris-buffer (seq-find
+                           (lambda (b) (eq 'idris-mode (buffer-local-value 'major-mode b)))
+                           (buffer-list))))
+        (if idris-buffer
+            (pop-to-buffer idris-buffer `(display-buffer-reuse-window))
+          (user-error "No Idris buffer found")))
     (user-error "Not in a Idris REPL buffer")))
 
 (defun idris-quit ()

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -949,6 +949,24 @@ type-correct, so loading will fail."
         (pop-to-buffer buf)
       (error "No Idris REPL buffer is open."))))
 
+(defun idris-switch-to-last-idris-buffer ()
+  "Switch to the last Idris buffer.
+The default keybinding for this command is
+the same as variable `idris-pop-to-repl',
+so that it is very convenient to jump between a
+Idris buffer and the REPL buffer.
+
+Inspired by `cider-switch-to-last-clojure-buffer'
+https://github.com/clojure-emacs/cider"
+  (interactive)
+  (if (derived-mode-p 'idris-repl-mode)
+      (if-let* ((a-buf (seq-find
+                        (lambda (b) (eq 'idris-mode (buffer-local-value 'major-mode b)))
+                        (buffer-list))))
+          (pop-to-buffer a-buf `(display-buffer-reuse-window))
+        (user-error "No Idris buffer found"))
+    (user-error "Not in a Idris REPL buffer")))
+
 (defun idris-quit ()
   "Quit the Idris process, cleaning up the state synchronized with Emacs."
   (interactive)

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -187,6 +187,9 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
                   idris-define-general-keys
                   idris-define-active-term-keys)
              do (funcall keyer map))
+    (substitute-key-definition 'idris-pop-to-repl
+                               'idris-switch-to-last-idris-buffer
+                               map)
     map)
   "Keymap used in Idris REPL mode.")
 


### PR DESCRIPTION
last Idris source code file using:
`M-x idris-switch-to-last-idris-buffer` or key binding
 used to jump from a file to repl (`C-c C-z` by default).

This is simplified version of `cider-switch-to-last-clojure-buffer` from https://github.com/clojure-emacs/cider/blob/master/cider-mode.el#L122-L145

Demo:

https://user-images.githubusercontent.com/578608/200200640-e5be5d5c-a7ba-4259-917d-5a1297fa90de.mp4

