### PR TITLE
Compute file path to repl history file at runtime if

### DIFF
--- a/idris-repl.el
+++ b/idris-repl.el
@@ -216,7 +216,7 @@ Invokes `idris-repl-mode-hook'."
   (set (make-local-variable 'indent-tabs-mode) nil)
   (add-hook 'idris-event-hooks 'idris-repl-event-hook-function)
   (add-hook 'kill-buffer-hook 'idris-repl-remove-event-hook-function nil t)
-  (when idris-repl-history-file
+  (when (idris-repl-history-file-f)
     (idris-repl-safe-load-history)
     (add-hook 'kill-buffer-hook
               'idris-repl-safe-save-history nil t))
@@ -534,22 +534,31 @@ The handler will use qeuery to ask the use if the error should be ingored."
          nil
        (signal (car err) (cdr err))))))
 
+(defun idris-repl-history-file-f ()
+  "Return repl history file.
+
+Use `idris-repl-history-file' if set or fallback
+ to filepath computed from the `idris-interpreter-path'."
+  (or idris-repl-history-file
+      ;; We should use `file-name-concat' but it is only in Emacs version 28+
+      (concat "~/." (file-name-nondirectory idris-interpreter-path) "/idris-history.eld")))
+
 (defun idris-repl-read-history-filename ()
   (read-file-name "Use Idris REPL history from file: "
-                  idris-repl-history-file))
+                  (idris-repl-history-file-f)))
 
 (defun idris-repl-load-history (&optional filename)
   "Set the current Idris REPL history.
 It can be read either from FILENAME or `idris-repl-history-file' or
 from a user defined filename."
   (interactive (list (idris-repl-read-history-filename)))
-  (let ((file (or filename idris-repl-history-file)))
+  (let ((file (or filename (idris-repl-history-file-f))))
     (setq idris-repl-input-history (idris-repl-read-history file))))
 
 (defun idris-repl-read-history (&optional filename)
   "Read and return the history from FILENAME.
 The default value for FILENAME is `idris-repl-history-file'."
-  (let ((file (or filename idris-repl-history-file)))
+  (let ((file (or filename (idris-repl-history-file-f))))
     (cond ((not (file-readable-p file)) '())
           (t (with-temp-buffer
                (insert-file-contents file)
@@ -561,7 +570,7 @@ When Idris is setup to always load the old history and one uses only
 one instance of idris all the time, there is no need to merge the
 files and this function is sufficient."
   (interactive (list (idris-repl-read-history-filename)))
-  (let ((file (or filename idris-repl-history-file))
+  (let ((file (or filename (idris-repl-history-file-f)))
         (hist (or history idris-repl-input-history)))
     (unless (file-writable-p file)
       (error (format "History file not writable: %s" file)))

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -303,8 +303,8 @@ By default we assume Idris' default configuration home is:
   $HOME/.idris/idris-history.eld.
      
 If you have installed/configured Idris differently, or are 
-using Idris2, then you may wish to customise this variable.
-"
+using Idris2, then you may wish to customise this variable."
+
   :type 'string
   :group 'idris-repl)
 

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -298,7 +298,13 @@ Set to `nil' for no banner."
 (defcustom idris-repl-history-file nil
   "File to save the persistent REPL history to.
 
-Defaults to ~/.[:IDRIS_EXECUTABLE_NAME:]/idris-history.eld"
+By default we assume Idris' default configuration home is:
+ 
+  $HOME/.idris/idris-history.eld.
+     
+If you have installed/configured Idris differently, or are 
+using Idris2, then you may wish to customise this variable.
+"
   :type 'string
   :group 'idris-repl)
 

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -295,8 +295,10 @@ Set to `nil' for no banner."
   "Face for the result of an evaluation in the Idris REPL."
   :group 'idris-repl)
 
-(defcustom idris-repl-history-file "~/.idris/idris-history.eld"
-  "File to save the persistent REPL history to."
+(defcustom idris-repl-history-file nil
+  "File to save the persistent REPL history to.
+
+Defaults to ~/.[:IDRIS_EXECUTABLE_NAME:]/idris-history.eld"
   :type 'string
   :group 'idris-repl)
 


### PR DESCRIPTION
it is not specified by user using `idris-repl-history-file` variable.

Why:
Previously the `idris-repl-history-file` used as default hardcoded path `~/.idris/idris-history.eld`. However the Idris 2 uses/creates
 `~/.idris2` directory, meaning if an user with only Idris 2 installed
tries to exit Emacs he is prompted with an error:

```
History file not writable: ~/.idris/idris-history.eld" while saving the
history. Continue? (y or n)
```

This change also allows users with both Idris and Idris2 installed switch between them just by changing the interpreter variable and have separate repl histories for both version.