### PR TITLE
Revert removal of `s` flag from `interactive` function argument.

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -544,14 +544,15 @@ KILLFLAG is set if N was explicitly specified."
     ;; `delete-forward-char' does
     (t (delete-char 1 killflag))))
 
+
 (defun idris-apropos (what)
-  "Look up WHAT in names, type signatures, and docstrings"
-  (interactive "Search Idris docs for: ")
+  "Look up WHAT in names, type signatures, and docstrings."
+  (interactive "sSearch Idris docs for: ")
   (idris-info-for-name :apropos what))
 
 (defun idris-type-search (what)
-  "Search the Idris libraries for WHAT by fuzzy type matching"
-  (interactive "Search for type: ")
+  "Search the Idris libraries for WHAT by fuzzy type matching."
+  (interactive "sSearch for type: ")
   (idris-info-for-name :interpret (concat ":search " what)))
 
 (defun idris-docs-at-point (thing)

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -157,6 +157,17 @@ remain."
       (kill-buffer))
     (idris-quit)))
 
+(ert-deftest idris-test-idris-type-search ()
+  "Test that `idris-type-search' produces output in Idris info buffer."
+  (let ((buffer (find-file "test-data/Empty.idr")))
+    (with-current-buffer buffer
+      (idris-load-file)
+      (funcall-interactively 'idris-type-search "Nat"))
+    (with-current-buffer (get-buffer idris-info-buffer-name)
+      (goto-char (point-min))
+      (should (re-search-forward "Zero" nil t)))
+    (idris-quit)))
+
 (ert-deftest idris-test-ipkg-packages-with-underscores-and-dashes ()
   "Test that loading an ipkg file can have dependencies on packages with _ or - in the name."
   (let ((buffer (find-file "test-data/package-test/Packaging.idr")))

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -159,7 +159,7 @@ remain."
 
 (ert-deftest idris-test-idris-type-search ()
   "Test that `idris-type-search' produces output in Idris info buffer."
-  (let ((buffer (find-file "test-data/Empty.idr")))
+  (let ((buffer (find-file "test-data/AddClause.idr")))
     (with-current-buffer buffer
       (idris-load-file)
       (funcall-interactively 'idris-type-search "Nat"))


### PR DESCRIPTION
Why:
It is not typo but a flag. (mea culpa; got too excited fixing real typo)

Regression introduced in https://github.com/idris-hackers/idris-mode/pull/555
Will try add regression test 🤞🏻 