### PR TITLE
Fix failure to find beginning of function type definition

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -712,8 +712,8 @@ Otherwise, case split as a pattern variable."
                  ;; now we add the type signature - search upwards for the current
                  ;; signature, then insert before it
                  (re-search-backward (if (idris-lidr-p)
-                                         "^\\(>\\s-*\\)\\(([^)]+)\\|\\w+\\)\\s-*:"
-                                       "^\\(\\s-*\\)\\(([^)]+)\\|\\w+\\)\\s-*:"))
+                                         "^\\(>\\s-*\\)\\(([^)]+)\\|[a-zA-Z_0-9]+\\)\\s-*:"
+                                       "^\\(\\s-*\\)\\(([^)]+)\\|[a-zA-Z_0-9]+\\)\\s-*:"))
                  (let ((indentation (match-string 1)) end-point)
                    (beginning-of-line)
                    (insert indentation)

--- a/test-data/MakeLemma.idr
+++ b/test-data/MakeLemma.idr
@@ -3,8 +3,6 @@ module MakeLemma
 -- (idris-test-run-goto-char #'idris-make-lemma)
 data Test = A | B
 
-test : Test -> Test
+my_lemmaTest : Test -> Test
 --       +++++++++++
-test x = ?make_lemma
-
-
+my_lemmaTest x = ?my_lemmaTest_rhs


### PR DESCRIPTION
when lifting hole and function name contains underscore. 
Previously in such case the `M-x make-lemma` command ends with:
```
Test idris-make-lemma/test-data/MakeLemma condition:
    (search-failed "^\\(\\s-*\\)\\(([^)]+)\\|\\w+\\)\\s-*:")
```

Tested with Idris 1.3.3 and Idris 2

We may probably at some point need to update regexps https://github.com/idris-hackers/idris-mode/blob/main/idris-commands.el#L732-L733
but as we do not have tests for that scenario and I don't know yet how to test that manually, saving that for later.