### PR TITLE
Idris2: display one line error message in minibuffer

### DIFF
--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -340,7 +340,9 @@ or FAILURE-CONT in failure case."
      (when failure-cont
        (set-buffer buffer)
        (funcall failure-cont condition))
-     (message "Evaluation returned an error: %s." condition))))
+     ;; Using `(car (split-string condition ":"))' to avoid long
+     ;; multiline message in minibuffer returned by idris-protocol-version 2.1
+     (message "Evaluation returned an error: %s." (car (split-string condition ":"))))))
 
 ;;; Synchronous requests are implemented in terms of asynchronous
 ;;; ones. We make an asynchronous request with a continuation function


### PR DESCRIPTION
Change in IDE protocol in causes same error message being displayed in Emacs minibuffer and also in *idris-notes* buffer.

Interestingly Idris/REPL.idr  https://github.com/idris-lang/Idris2/blob/main/src/Idris/REPL.idr#L1241-L1242` prints out only filename as expected, while IDEMode/REPL.idr https://github.com/idris-lang/Idris2/blob/main/src/Idris/IDEMode/REPL.idr#L362-L363
prints also whole error causing this issue.

Maybe we will be able to change the behaviour in Idris2 so making this PR for time being as a draft.

Before change:

![async-minibuffer-before-change-idris2](https://user-images.githubusercontent.com/578608/201438024-c7440ea4-df25-4eae-a18e-83899ee726bd.jpg)

After change:

![async-minibuffer-after-change-idris2](https://user-images.githubusercontent.com/578608/201438044-a837473a-b117-42b8-9327-55c688bbaba4.jpg)

Idris 1.3 before/after change:

![async-minibuffer-after-and-before-change-idris1-3](https://user-images.githubusercontent.com/578608/201438080-ec6b971b-bfee-4e67-9dd1-454121b74b93.jpg)

