### PR TITLE
Move "words of encouragement" from minibuffer to Idris repl banner

### DIFF
--- a/idris-repl.el
+++ b/idris-repl.el
@@ -96,7 +96,9 @@ Returns non-`nil' on success, `nil' on failure."
                  version-string)
         (insert (propertize (concat "Idris " version-string)
                             'face 'italic)
-                "\n\n")))))
+                "\n")))
+    (when idris-display-words-of-encouragement
+      (insert (idris-random-words-of-encouragement) "\n"))))
 
 (defun idris-repl-insert-prompt (&optional always-insert)
   "Insert or update Idris prompt in buffer.

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -141,9 +141,7 @@ directory variables.")
     (set-process-query-on-exit-flag idris-connection t)
     (setq idris-process-current-working-directory "")
     (run-hooks 'idris-run-hook)
-    (when idris-display-words-of-encouragement
-      (message "Connected. %s" (idris-random-words-of-encouragement)))
-    ))
+    (message "Connection to Idris established.")))
 
 (defun idris-sentinel (_process msg)
   (message "Idris disconnected: %s" (substring msg 0 -1))


### PR DESCRIPTION
Why:
To split concerns of "logging that Idris connection was created" and displaying "words of encouragement for user".
To ensure that the words of encouragement are visible to user.

Relates to: https://github.com/idris-hackers/idris-mode/pull/564

After change:

![words-encouragement-repl-banner-v2](https://user-images.githubusercontent.com/578608/201523241-9437c500-feef-4057-873c-eb9a591592e2.jpg)

Messages buffer:

![messages-emacs](https://user-images.githubusercontent.com/578608/201523258-66d5a6c4-092b-4e7b-94a3-0bdea2ea71ad.jpg)

