### PR TITLE
Inline `idris-get-line-num` by using native `line-number-at-pos`

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -324,12 +324,8 @@ Idris process. This sets the load position to point, if there is one."
 
 
 (defun idris-get-line-num ()
-  "Get the current line number"
-  (save-restriction
-    (widen)
-    (save-excursion
-      (beginning-of-line)
-      (1+ (count-lines 1 (point))))))
+  "Get the current line absolute number."
+  (line-number-at-pos (point) t))
 
 
 (defun idris-thing-at-point ()


### PR DESCRIPTION
Why:
To reduce complexity of codebase.
`(line-number-at-pos &optional POSITION ABSOLUTE)`
  Probably introduced at or before Emacs version 22.1.