### PR TITLE
Simplify code

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -97,7 +97,7 @@ Lisp package.")
 (defmacro idris-save-marker (marker &rest body)
   "Save the contents of the marker MARKER while executing BODY."
   (declare (indent 1))
-  (let ((pos (cl-gensym "pos")))
+  (let ((pos (gensym "pos")))
   `(let ((,pos (marker-position ,marker)))
      (prog1 (progn . ,body)
        (set-marker ,marker ,pos)))))
@@ -107,7 +107,7 @@ Lisp package.")
 More precisely, PROPS are added to the region between the point's
 positions before and after executing BODY."
   (declare (indent 1))
-  (let ((start (cl-gensym)))
+  (let ((start (gensym "foo")))
     `(let ((,start (point)))
        (prog1 (progn ,@body)
          (add-text-properties ,start (point) ,props)))))
@@ -116,7 +116,7 @@ positions before and after executing BODY."
   "Execute BODY and add the properties indicated by SPANS to the
 inserted text (that is, relative to point prior to insertion)."
   (declare (indent 1))
-  (let ((start (cl-gensym)))
+  (let ((start (gensym)))
     `(let ((,start (point)))
        (prog1 (progn ,@body)
          (cl-loop for (begin length props) in ,spans
@@ -174,7 +174,7 @@ inserted text (that is, relative to point prior to insertion)."
                       (:underline '(underline))
                       (_ nil)))
          (link-face (if link-href '(idris-link-face) ()))
-         (unique-val (cl-gensym)) ; HACK to stop consecutive mouse-faces from interfering
+         (unique-val (gensym)) ; HACK to stop consecutive mouse-faces from interfering
          (mousable-face
           (cond ((member (cadr decor) idris-semantic-properties-clickable-decors)
                  `((:inherit (,decor-face highlight) :hack ,unique-val)))
@@ -348,9 +348,9 @@ The list of patterns is searched for a HEAD `eq' to the car of
 VALUE. If one is found, the BODY is executed with ARGS bound to the
 corresponding values in the CDR of VALUE."
   (declare (indent 1))
-  (let ((operator (cl-gensym "op-"))
-        (operands (cl-gensym "rand-"))
-        (tmp (cl-gensym "tmp-")))
+  (let ((operator (gensym "op-"))
+        (operands (gensym "rand-"))
+        (tmp (gensym "tmp-")))
     `(let* ((,tmp ,value)
             (,operator (car ,tmp))
             (,operands (cdr ,tmp)))

--- a/idris-compat.el
+++ b/idris-compat.el
@@ -30,5 +30,9 @@ attention to case differences."
            (eq t (compare-strings suffix nil nil
                                   string start-pos nil ignore-case))))))
 
+;; gensym fun introduced at or before Emacs version 26.1.
+(unless (fboundp 'gensym)
+  (defalias 'gensym 'cl-gensym))
+
 (provide 'idris-compat)
 ;;; idris-compat.el ends here

--- a/idris-info.el
+++ b/idris-info.el
@@ -135,7 +135,7 @@ Ensure that the buffer is in `idris-info-mode'."
 (defmacro with-idris-info-buffer (&rest cmds)
   "Execute `CMDS' in a fresh Idris info buffer, then display it to the user."
   (declare (indent defun))
-  (let ((str-info (cl-gensym "STR-INFO")))
+  (let ((str-info (gensym "STR-INFO")))
     `(let ((,str-info (with-temp-buffer
                         ,@cmds
                         (buffer-string))))

--- a/idris-prover.el
+++ b/idris-prover.el
@@ -139,7 +139,7 @@ string and whose cadr is highlighting information."
 
 (defun idris-prover-complete ()
   "Completion of the current input."
-  (let* ((start (save-excursion (beginning-of-line) (point)))
+  (let* ((start (line-beginning-position))
          (input (buffer-substring-no-properties
                  start
                  (point)))

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -64,7 +64,7 @@
          (button-text `(,(format "%s line %s col %s:" (nth 0 note) (nth 1 note) (nth 2 note))
                         help-echo "go to source location"
                         action ,#'(lambda (_)
-                                    (idris-show-source-location (nth 0 note)
+                                    (idris-goto-source-location (nth 0 note)
                                                                 (nth 1 note)
                                                                 (nth 2 note))))))
     (make-idris-tree :item (nth 3 note)
@@ -117,10 +117,7 @@ Invokes `idris-compiler-notes-mode-hook'."
     (cond ((not (idris-tree-leaf-p tree))
            (idris-tree-toggle tree))
           (t
-           (idris-show-source-location (nth 0 note) (nth 1 note) (nth 2 note))))))
-
-(defun idris-show-source-location (filename lineno col)
-  (idris-goto-source-location filename lineno col))
+           (idris-goto-source-location (nth 0 note) (nth 1 note) (nth 2 note))))))
 
 (defun idris-goto-location (filename)
   "Opens buffer for filename"

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -160,7 +160,7 @@ a preview and offer to widen."
   "Like with-slots but works only for structs.
 \(fn (CONC-NAME &rest SLOTS) STRUCT &body BODY)"
   (declare (indent 2))
-  (let ((struct-var (cl-gensym "struct")))
+  (let ((struct-var (gensym "struct")))
     `(let ((,struct-var ,struct))
        (cl-symbol-macrolet
            ,(mapcar (lambda (slot)

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -309,7 +309,7 @@ asynchronously.
 Note: don't use backquote syntax for SEXP, because various Emacs
 versions cannot deal with that."
   (declare (indent 3))
-  (let ((result (cl-gensym)))
+  (let ((result (gensym)))
     `(let ,(cl-loop for var in saved-vars
                     collect (cl-etypecase var
                               (symbol (list var var))
@@ -354,7 +354,7 @@ or FAILURE-CONT in failure case."
 ignoring intermediate output. If `NO-ERRORS' is non-nil, don't
 trigger warning buffers and don't call `ERROR' if there was an
 Idris error."
-  (let* ((tag (cl-gensym (format "idris-result-%d-"
+  (let* ((tag (gensym (format "idris-result-%d-"
                                  (1+ idris-continuation-counter))))
          (idris-stack-eval-tags (cons tag idris-stack-eval-tags)))
     (apply


### PR DESCRIPTION
**Why:**
To improve maintainability of codebase.

**What:**

- Replace `cl-gensym` with Emacs >= 26.1 own  `gensym`  and keep fallback for older versions of Emacs
- Replace `(save-excursion (beginning-of-line) (point))` with `(line-beginning-position)`
- Remove  `idris-show-source-location` that become some time ago the same as `idris-goto-source-location`