### PR TITLE
Improve `idris-case-dwim` to make case expression from hole in edge cases

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -629,10 +629,15 @@ Useful for writing papers or slides."
   "If point is on a hole name, make it into a case expression.
 Otherwise, case split as a pattern variable."
   (interactive)
-  (if (or (looking-at-p "\\?[a-zA-Z_]+")
-          (looking-back "\\?[a-zA-Z0-9_]+" nil))
-      (idris-make-cases-from-hole)
-    (idris-case-split)))
+  (cond
+   ((looking-at-p "\\?[a-zA-Z_]+") ;; point at "?" in ?hole_rs1
+    (forward-char) ;; move from "?" for idris-make-cases-from-hole to work correctly
+    (idris-make-cases-from-hole))
+   ((or (and (char-equal (char-before) ??) ;; point at "h" in ?hole_rs1
+             (looking-at-p "[a-zA-Z_]+"))
+        (looking-back "\\?[a-zA-Z0-9_]+" nil)) ;; point somewhere afte "?h" in ?hole_rs1
+    (idris-make-cases-from-hole))
+   (t (idris-case-split))))
 
 (defun idris-add-clause (proof)
   "Add clauses to the declaration at point"


### PR DESCRIPTION
when:

1) point is at ? in `?hole_rs1`  
  Currently:
  _Idris 1.3_ errors with "Can’t make cases from ?"
  _Idris2_ does not errors but moves the point at the end of the hole 
2) point is at char after ? in `?hole_rs1`
 Currently:
  _Idris 1.3_ errors with "funcall: example_rhs is not a pattern variable (synchronous Idris evaluation failed)")
  _Idris2_ errros with "funcall: example_rhs not defined here (synchronous Idris evaluation failed)"

Resolves: https://github.com/idris-hackers/idris-mode/issues/441