### PR TITLE
Consider `-` as operator in `idris-thing-at-point`

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -326,14 +326,17 @@ Idris process. This sets the load position to point, if there is one."
     (error "Cannot find file for current buffer")))
 
 
+(defun idris-operator-at-position-p (pos)
+  "Return t if syntax lookup is `.' or char after POS is `-'."
+  (or (equal (syntax-after pos) (string-to-syntax "."))
+      (eq (char-after pos) ?-)))
+
 (defun idris-thing-at-point ()
   "Return the line number and name at point as a cons.
 Use this in Idris source buffers."
   (let ((line (idris-get-line-num (point))))
     (cons
-     (if (equal (syntax-after (point))
-                (string-to-syntax "."))
-         ;; We're on an operator.
+     (if (idris-operator-at-position-p (point))
          (save-excursion
            (skip-syntax-backward ".")
            (let ((beg (point)))

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -178,5 +178,28 @@ remain."
       (kill-buffer buffer))
     (idris-quit)))
 
+(ert-deftest idris-test-idris-add-clause ()
+  "Test that `idris-add-clause' generates definition with hole."
+  (let ((buffer (find-file "test-data/AddClause.idr"))
+        (buffer-content (with-temp-buffer
+                          (insert-file-contents "AddClause.idr")
+                          (buffer-string))))
+    (with-current-buffer buffer
+      (goto-char (point-min))
+      (re-search-forward "test :")
+      (goto-char (match-beginning 0))
+      (funcall-interactively 'idris-add-clause nil)
+      (should (looking-at-p "test \\w+ = \\?test_rhs"))
+      (re-search-forward "(-) :")
+      (goto-char (1+ (match-beginning 0)))
+      (funcall-interactively 'idris-add-clause nil)
+      (should (looking-at-p "(-) = \\?\\w+_rhs"))
+      ;; Cleanup
+      (erase-buffer)
+      (insert buffer-content)
+      (save-buffer)
+      (kill-buffer)))
+  (idris-quit))
+
 (provide 'idris-tests)
 ;;; idris-tests.el ends here

--- a/test-data/AddClause.idr
+++ b/test-data/AddClause.idr
@@ -5,3 +5,7 @@ data Test = A | B
 --++++++++++++++++
 test : Test -> Int
 
+-- Regression test for:
+-- idris-add-clause doesn't send a message when cursor is on a dash
+-- https://github.com/idris-community/idris2-mode/issues/16
+(-) : Nat

--- a/test-data/AddClause.idr
+++ b/test-data/AddClause.idr
@@ -4,6 +4,4 @@ data Test = A | B
 
 --++++++++++++++++
 test : Test -> Int
-test x = ?test_rhs
-
 


### PR DESCRIPTION
**Why:**
The `-` char is defined in idris-syntax-table as being beginning of comment and causing condition:
`(equal (syntax-after (point)) (string-to-syntax ".")` in `idris-thing-at-point` be evaluated to nil (false) and throw error.

**Fixes:**
https://github.com/idris-community/idris2-mode/issues/16

![output-2022-11-26-21:57:29](https://user-images.githubusercontent.com/578608/204110498-037daa34-7017-4f6a-bc45-3953369a6982.gif)
