### PR TITLE
Update idris-compile-and-execute for Idris2

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -748,12 +748,15 @@ Otherwise, case split as a pattern variable."
                        ;; make sure point is at new defn
                        (goto-char end)))))))))))
 
-
 (defun idris-compile-and-execute ()
-  "Execute the program in the current buffer"
+  "Execute the program in the current buffer."
   (interactive)
   (idris-load-file-sync)
-  (idris-eval '(:interpret ":exec")))
+  (if (>=-protocol-version 2 1)
+      (let ((name (read-string "MExpression to compile & execute (default main): "
+                                     nil nil "main")))
+        (idris-repl-eval-string (format ":exec %s" name) 0))
+    (idris-eval '(:interpret ":exec"))))
 
 (defvar-local proof-region-start nil
   "The start position of the last proof region.")

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -989,7 +989,9 @@ https://github.com/clojure-emacs/cider"
         (delete-overlay idris-loaded-region-overlay)
         (setq idris-loaded-region-overlay nil)))
     (idris-prover-end)
-    (idris-kill-buffers)))
+    (idris-kill-buffers)
+    (setq idris-protocol-version 0
+          idris-protocol-version-minor 0)))
 
 (defun idris-delete-ibc (no-confirmation)
   "Delete the IBC file for the current buffer. A prefix argument


### PR DESCRIPTION

Backport of idris2-compile-and-execute from https://github.com/idris-community/idris2-mode/pull/20/files
with preserving backward compatibility for Idris 1

Also includes reset idris-protocol-version* vars to 0 on `idris-quit`.

**Idris1 idris-compile-and-execute**
![idris-compile-and-execute-idris1](https://user-images.githubusercontent.com/578608/204424335-4512c284-f27d-424b-b05f-8e1c0593d84c.gif)

**Idris2  idris-compile-and-execute**
![idris-compile-and-execute-idris2-default](https://user-images.githubusercontent.com/578608/204424454-b90f3307-94d0-4071-b79a-b5cf40c8400e.gif)

**Idris2 idris-compile-and-execute with custom function**
![idris-compile-and-execute-idris2-custom](https://user-images.githubusercontent.com/578608/204424463-319c197e-ccf9-4370-8de8-9ea5d9e7ebd8.gif)
