### PR TITLE
Apply minor internal improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,6 @@ test2: getdeps build
 test3: getdeps build
 	$(BATCHEMACS) -L . \
 		-eval '(setq idris-interpreter-path (executable-find "idris2"))' \
-		-eval '(setq idris-repl-history-file "idris2-history.eld")' \
-		-eval '(setq idris-log-events t)' \
 		-l ert -l idris-tests3.el -f ert-run-tests-batch-and-exit
 
 clean:

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -268,8 +268,8 @@ A prefix argument forces loading but only up to the current line."
              (when (member 'warnings-tree idris-warnings-printing)
                (idris-list-compiler-notes)
                (if idris-stay-in-current-window-on-compiler-error
-                 (display-buffer (idris-buffer-name :notes))
-                 (pop-to-buffer (idris-buffer-name :notes))))))))
+                 (display-buffer idris-notes-buffer-name)
+                 (pop-to-buffer idris-notes-buffer-name)))))))
     (error "Cannot find file for current buffer")))
 
 (defun idris-view-compiler-log ()

--- a/idris-hole-list.el
+++ b/idris-hole-list.el
@@ -73,9 +73,6 @@ Invoces `idris-hole-list-mode-hook'."
   "Return the Idris hole buffer, creating one if there is not one"
   (get-buffer-create idris-hole-list-buffer-name))
 
-(defun idris-hole-list-buffer-visible-p ()
-  (if (get-buffer-window idris-hole-list-buffer-name 'visible) t nil))
-
 (defun idris-hole-list-show (hole-info)
   (if (null hole-info)
       (progn (message "No holes found!")


### PR DESCRIPTION
 - Use idris-notes-buffer-name variable in idris-commands.el
 - Remove unused idris-hole-list-buffer-visible-p
 - Remove Idris event logging and custom history file from make test3

Why:
To improve maintainability
