### PR TITLE
[semantic-highlight] Remove and rebuild overlays in file on reload  only in changed area

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -209,8 +209,6 @@ A prefix argument forces loading but only up to the current line."
         (when (get-buffer idris-notes-buffer-name)
           (with-current-buffer idris-notes-buffer-name
             (let ((inhibit-read-only t)) (erase-buffer))))
-        ;; Remove stale semantic highlighting
-        (idris-highlight-remove-overlays (current-buffer))
         ;; Actually do the loading
         (let* ((dir-and-fn (idris-filename-to-load))
                (fn (cdr dir-and-fn))


### PR DESCRIPTION

**Why:**
Currently when file is reloaded to Idris
all overlays are removed from buffer and added back later. This causes flashing and bad user experience.
After change only overlays in changed area are removed and redrawn.

**Before change:**

https://user-images.githubusercontent.com/578608/205518573-e53689a3-35a7-4b31-858f-79c005a21e16.mp4


**After change**

https://user-images.githubusercontent.com/578608/205518588-a416a238-2695-426f-9790-ded476490baa.mp4

