### PR TITLE
Make idris-compiler-notes-mode derived from special-mode and

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -914,6 +914,12 @@ type-correct, so loading will fail."
   (interactive)
   (idris-hole-list-show (car (idris-eval '(:metavariables 80)))))
 
+(defun idris-list-compiler-notes ()
+  "Show the compiler notes in tree view."
+  (interactive)
+  (with-temp-message "Preparing compiler note tree..."
+    (idris-compiler-notes-list-show (reverse idris-raw-warnings))))
+
 (defun idris-kill-buffers ()
   (idris-warning-reset-all)
   (setq idris-currently-loaded-buffer nil)

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -243,10 +243,7 @@ A prefix argument forces loading but only up to the current line."
                   (idris-update-loaded-region result))))
            (lambda (_condition)
              (when (member 'warnings-tree idris-warnings-printing)
-               (idris-list-compiler-notes)
-               (if idris-stay-in-current-window-on-compiler-error
-                 (display-buffer idris-notes-buffer-name)
-                 (pop-to-buffer idris-notes-buffer-name)))))))
+               (idris-list-compiler-notes))))))
     (error "Cannot find file for current buffer")))
 
 (defun idris-view-compiler-log ()

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -100,7 +100,7 @@
 
 (defun idris-notes-quit ()
   (interactive)
-  (idris-kill-buffer :notes))
+  (idris-kill-buffer idris-notes-buffer-name))
 
 (define-derived-mode idris-compiler-notes-mode fundamental-mode "Compiler-Notes"
   "Idris compiler notes

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -37,24 +37,23 @@
 
 (defun idris-compiler-notes-list-show (notes)
   (with-current-buffer (get-buffer-create idris-notes-buffer-name)
-      (idris-compiler-notes-mode)
-      (setq buffer-read-only nil)
-      (erase-buffer)
-      (when notes
-        (let ((root (idris-compiler-notes-to-tree notes)))
-          (idris-tree-insert root "")
-          (insert "\n")
-          (message "Press q to close, return or mouse on error to navigate to source")
-          (setq buffer-read-only t)
-          (goto-char (point-min))
-          notes
-          (display-buffer idris-notes-buffer-name)))))
+    (idris-compiler-notes-mode)
+    (if (null notes)
+        nil
+      (let ((buffer-read-only nil)
+            (root (idris-compiler-notes-to-tree notes)))
+        (erase-buffer)
+        (idris-tree-insert root "")
+        (insert "\n\n")
+        (message "Press q to close, return or mouse on error to navigate to source")
+        (goto-char (point-min))
+        (display-buffer idris-notes-buffer-name)))))
 
 (defun idris-list-compiler-notes ()
   "Show the compiler notes in tree view."
   (interactive)
   (with-temp-message "Preparing compiler note tree..."
-    (idris-complier-notes-list-show (reverse idris-raw-warnings))))
+    (idris-compiler-notes-list-show (reverse idris-raw-warnings))))
 
 (defvar idris-tree-printer 'idris-tree-default-printer)
 
@@ -81,7 +80,6 @@
 
 (defvar idris-compiler-notes-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "q") 'idris-notes-quit)
     ;;; Allow buttons to be clicked with the left mouse button in the compiler notes
     (define-key map [follow-link] 'mouse-face)
     (cl-loop for keyer
@@ -102,9 +100,10 @@
   (interactive)
   (idris-kill-buffer idris-notes-buffer-name))
 
-(define-derived-mode idris-compiler-notes-mode fundamental-mode "Compiler-Notes"
-  "Idris compiler notes
-     \\{idris-compiler-notes-mode-map}
+
+(define-derived-mode idris-compiler-notes-mode special-mode "Compiler-Notes"
+  "Major mode for displaying Idris compiler notes.
+\\{idris-compiler-notes-mode-map}
 Invokes `idris-compiler-notes-mode-hook'."
   (setq-local prop-menu-item-functions '(idris-context-menu-items)))
 

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -33,7 +33,9 @@
 (require 'idris-common-utils)
 
 (defvar idris-notes-buffer-name (idris-buffer-name :notes)
-  "The name of the buffer containing Idris errors")
+  "The name of the buffer containing Idris errors.")
+
+(defvar idris-tree-printer 'idris-tree-default-printer)
 
 (defun idris-compiler-notes-list-show (notes)
   (if (null notes)
@@ -48,14 +50,6 @@
         (message "Press q to close, return or mouse on error to navigate to source")
         (goto-char (point-min))))
     (display-buffer idris-notes-buffer-name)))
-
-(defun idris-list-compiler-notes ()
-  "Show the compiler notes in tree view."
-  (interactive)
-  (with-temp-message "Preparing compiler note tree..."
-    (idris-compiler-notes-list-show (reverse idris-raw-warnings))))
-
-(defvar idris-tree-printer 'idris-tree-default-printer)
 
 (defun idris-tree-for-note (note)
   (let* ((buttonp (> (length (nth 0 note)) 0)) ;; if empty source location

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -35,27 +35,26 @@
 (defvar idris-notes-buffer-name (idris-buffer-name :notes)
   "The name of the buffer containing Idris errors")
 
+(defun idris-compiler-notes-list-show (notes)
+  (with-current-buffer (get-buffer-create idris-notes-buffer-name)
+      (idris-compiler-notes-mode)
+      (setq buffer-read-only nil)
+      (erase-buffer)
+      (when notes
+        (let ((root (idris-compiler-notes-to-tree notes)))
+          (idris-tree-insert root "")
+          (insert "\n")
+          (message "Press q to close, return or mouse on error to navigate to source")
+          (setq buffer-read-only t)
+          (goto-char (point-min))
+          notes
+          (display-buffer idris-notes-buffer-name)))))
+
 (defun idris-list-compiler-notes ()
   "Show the compiler notes in tree view."
   (interactive)
   (with-temp-message "Preparing compiler note tree..."
-    (let ((notes (reverse idris-raw-warnings))
-          (buffer (get-buffer-create idris-notes-buffer-name)))
-      (with-current-buffer buffer
-        (idris-compiler-notes-mode)
-        (setq buffer-read-only nil)
-        (erase-buffer)
-        (if (null notes)
-            nil
-          (let ((root (idris-compiler-notes-to-tree notes)))
-            (idris-tree-insert root "")
-            (insert "\n")
-            (message "Press q to close, return or mouse on error to navigate to source")
-            (setq buffer-read-only t)
-            (goto-char (point-min))
-            notes
-            (display-buffer idris-notes-buffer-name)
-          ))))))
+    (idris-complier-notes-list-show (reverse idris-raw-warnings))))
 
 (defvar idris-tree-printer 'idris-tree-default-printer)
 

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -36,18 +36,18 @@
   "The name of the buffer containing Idris errors")
 
 (defun idris-compiler-notes-list-show (notes)
-  (with-current-buffer (get-buffer-create idris-notes-buffer-name)
-    (idris-compiler-notes-mode)
-    (if (null notes)
-        nil
+  (if (null notes)
+      nil ;; See https://github.com/idris-hackers/idris-mode/pull/148 TODO: revisit
+    (with-current-buffer (get-buffer-create idris-notes-buffer-name)
+      (idris-compiler-notes-mode)
       (let ((buffer-read-only nil)
             (root (idris-compiler-notes-to-tree notes)))
         (erase-buffer)
         (idris-tree-insert root "")
         (insert "\n\n")
         (message "Press q to close, return or mouse on error to navigate to source")
-        (goto-char (point-min))
-        (display-buffer idris-notes-buffer-name)))))
+        (goto-char (point-min))))
+    (display-buffer idris-notes-buffer-name)))
 
 (defun idris-list-compiler-notes ()
   "Show the compiler notes in tree view."

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -354,7 +354,7 @@ or FAILURE-CONT in failure case."
 (defvar idris-stack-eval-tags nil
   "List of stack-tags of continuations waiting on the stack.")
 
-(autoload 'idris-list-compiler-notes "idris-warnings-tree.el")
+(autoload 'idris-list-compiler-notes "idris-commands.el")
 (defun idris-eval (sexp &optional no-errors)
   "Evaluate EXPR on the inferior Idris and return the result,
 ignoring intermediate output. If `NO-ERRORS' is non-nil, don't

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -379,8 +379,7 @@ Idris error."
           (if no-errors
               (throw tag (list #'identity nil))
             (when (member 'warnings-tree idris-warnings-printing)
-              (when (idris-list-compiler-notes)
-                (pop-to-buffer (idris-buffer-name :notes))))
+              (idris-list-compiler-notes))
             (throw tag (list #'error "%s (synchronous Idris evaluation failed)" condition)))))
        (let ((debug-on-quit t)
              (inhibit-quit nil))


### PR DESCRIPTION
align code structure of idris-list-compiler-notes with idris-hole-list-show.

![idris-comp-notes-list-show-vs-hole-list-show](https://user-images.githubusercontent.com/578608/206048950-1d582b44-f86c-4fbc-9858-9e1998dce9ac.jpg)

Also includes few small improvements (see commits for details)

**Why**:
To improve maintainability.
This PR may also fix issue with company-mode https://github.com/idris-community/idris2-mode/issues/36 or atleast get us closer as it removes unnecessary calls to `pop-to-buffer/display-buffer` .

**Next steps**:
- remove now unused variable idris-stay-in-current-window-on-compiler-error 
- ensure that the *notes* buffer is not displayed in the same window as the loaded file when first connection to idris is created