### PR TITLE
Restore position after case split

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -570,19 +570,20 @@ Useful for writing papers or slides."
 
 
 (defun idris-case-split ()
-  "Case split the pattern variable at point"
+  "Case split the pattern variable at point."
   (interactive)
   (let ((what (idris-thing-at-point)))
     (when (car what)
       (save-excursion (idris-load-file-sync))
-      (let ((result (car (idris-eval `(:case-split ,(cdr what) ,(car what))))))
+      (let ((result (car (idris-eval `(:case-split ,(cdr what) ,(car what)))))
+            (initial-position (point)))
         (if (<= (length result) 2)
             (message "Can't case split %s" (car what))
           (delete-region (line-beginning-position) (line-end-position))
           (if (> idris-protocol-version 1)
               (insert (substring result 0 (length result)))
-              (insert (substring result 0 (1- (length result))))
-              ))))))
+            (insert (substring result 0 (1- (length result)))))
+          (goto-char initial-position))))))
 
 (defun idris-make-cases-from-hole ()
   "Make a case expression from the metavariable at point."
@@ -596,8 +597,8 @@ Useful for writing papers or slides."
           (delete-region (line-beginning-position) (line-end-position))
           (if (> idris-protocol-version 1)
               (insert (substring result 0 (length result)))
-              (insert (substring result 0 (1- (length result))))
-              ))))))
+            (insert (substring result 0 (1- (length result)))))
+          (search-backward "_ of\n"))))))
 
 (defun idris-case-dwim ()
   "If point is on a hole name, make it into a case expression.

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -75,6 +75,7 @@
 (defun idris-version-hook-function (event)
   (pcase event
     (`(:protocol-version ,version ,minor)
+     (message "-t- idris-version-hook-function 1")
      (setf idris-protocol-version version)
      (setf idris-protocol-version-minor minor)
      (remove-hook 'idris-event-hooks 'idris-version-hook-function)


### PR DESCRIPTION
Addresses feedback on https://github.com/idris-hackers/idris-mode/pull/465 with small improvement for making case from hole where the point is moved back to position of `_` in `case _ of` as that is place user may most likely edit next.

**After change**

![output-2022-12-07-00:56:42](https://user-images.githubusercontent.com/578608/206062479-c7d0089a-cb09-44d5-9200-dc550c7595bf.gif)

Closes https://github.com/idris-hackers/idris-mode/pull/465

