### PR TITLE
Display instead of pop into Idris repl buffer on startup

### DIFF
--- a/idris-repl.el
+++ b/idris-repl.el
@@ -143,7 +143,7 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
       (let ((buffer (get-buffer-create idris-repl-buffer-name)))
         (save-selected-window
           (when idris-repl-show-repl-on-startup
-            (pop-to-buffer buffer t))
+            (display-buffer buffer t))
           (with-current-buffer buffer
             (idris-repl-mode)
             (idris-repl-buffer-init))


### PR DESCRIPTION
Why:
To avoid warnings from Idris being displayed in same window as current code buffer on Idris connection and repl startup.

Looking at https://github.com/idris-hackers/idris-mode/issues/380 I think it was always suppose to be `display-buffer` instead of `pop-to-buffer`.

**Before change:**

![output-2022-12-09-00:17:04](https://user-images.githubusercontent.com/578608/206595982-b6bd2e36-811b-4ea0-a23a-fc13543bda6c.gif)

**After change:**

![output-2022-12-09-00:18:04](https://user-images.githubusercontent.com/578608/206596178-4ed6c360-b134-4c7b-a4b4-21584b599976.gif)


If user manualy starts repl with `M-x idris-repl` the point moves still as expected to the repl.

![output-2022-12-09-00:38:17](https://user-images.githubusercontent.com/578608/206596433-23f7a029-be1e-49d4-806f-536cf5ff0868.gif)
