### PR TITLE
Apply minor improvements to codebase

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -290,10 +290,10 @@ Idris process. This sets the load position to point, if there is one."
           (setq idris-currently-loaded-buffer nil)
           (idris-switch-working-directory srcdir)
           (let ((result
-                 (if idris-load-to-here
-                     (idris-eval `(:load-file ,fn
-                                              ,(idris-get-line-num idris-load-to-here)))
-                   (idris-eval `(:load-file ,fn)))))
+                 (idris-eval
+                  (if idris-load-to-here
+                      `(:load-file ,fn ,(idris-get-line-num idris-load-to-here))
+                    `(:load-file ,fn)))))
             (idris-update-options-cache)
             (setq idris-currently-loaded-buffer (current-buffer))
             (idris-make-clean)

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -122,15 +122,16 @@
              idris-set-current-pretty-print-width)
   :group 'idris)
 
-(defun idris-possibly-make-dirty (beginning end _length)
+(defun idris-possibly-make-dirty (_beginning _end _length)
+  (idris-make-dirty))
   ;; If there is a load-to-here marker and a currently loaded region, only
   ;; make the buffer dirty when the change overlaps the loaded region.
-  (if (and idris-load-to-here idris-loaded-region-overlay)
-      (when (member idris-loaded-region-overlay
-                    (overlays-in beginning end))
-        (idris-make-dirty))
-    ;; Otherwise just make it dirty.
-    (idris-make-dirty)))
+  ;; (if (and idris-load-to-here idris-loaded-region-overlay)
+  ;;     (when (member idris-loaded-region-overlay
+  ;;                   (overlays-in beginning end))
+  ;;       (idris-make-dirty))
+  ;;   ;; Otherwise just make it dirty.
+  ;; (idris-make-dirty)))
 
 
 (defun idris-update-loaded-region (fc)

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -940,6 +940,10 @@ type-correct, so loading will fail."
   (let ((bufs (list :connection :repl :proof-obligations :proof-shell :proof-script :log :info :notes :holes :tree-viewer)))
     (dolist (b bufs) (idris-kill-buffer b))))
 
+(defun idris-remove-event-hooks ()
+  "Remove Idris event hooks set after connection with Idris established."
+  (dolist (h idris-event-hooks) (remove-hook 'idris-event-hooks h)))
+
 (defun idris-pop-to-repl ()
   "Go to the REPL, if one is open."
   (interactive)
@@ -988,6 +992,7 @@ https://github.com/clojure-emacs/cider"
         (setq idris-loaded-region-overlay nil)))
     (idris-prover-end)
     (idris-kill-buffers)
+    (idris-remove-event-hooks)
     (setq idris-process-current-working-directory nil)
     (setq idris-protocol-version 0
           idris-protocol-version-minor 0)))

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -987,6 +987,7 @@ https://github.com/clojure-emacs/cider"
         (setq idris-loaded-region-overlay nil)))
     (idris-prover-end)
     (idris-kill-buffers)
+    (setq idris-process-current-working-directory nil)
     (setq idris-protocol-version 0
           idris-protocol-version-minor 0)))
 

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -66,8 +66,8 @@
 
 (defcustom idris-semantic-source-highlighting t
   "If non-nil, use the Idris compiler's semantic source
-information to highlight Idris code. If `debug', log failed
-  highlighting to buffer `*Messages*'."
+information to highlight Idris code.
+If `debug', log failed highlighting to buffer `*Messages*'."
   :group 'idris
   :type '(choice (boolean :tag "Enable")
                  (const :tag "Debug" debug)))
@@ -299,10 +299,10 @@ Set to `nil' for no banner."
   "File to save the persistent REPL history to.
 
 By default we assume Idris' default configuration home is:
- 
+
   $HOME/.idris/idris-history.eld.
-     
-If you have installed/configured Idris differently, or are 
+
+If you have installed/configured Idris differently, or are
 using Idris2, then you may wish to customise this variable."
 
   :type 'string

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -270,7 +270,7 @@ directory variables.")
 (defvar idris-continuation-counter 1
   "Continuation serial number counter.")
 
-(defvar idris-event-hooks)
+(defvar idris-event-hooks '())
 
 (defun idris-dispatch-event (event process)
   (or (run-hook-with-args-until-success 'idris-event-hooks event)


### PR DESCRIPTION
 improvements too small to get in alone.
Except "Reset Idris working directory on closing idris connection".
This make sure that after restarting connection with idris in the same directory the `idris-switch-working-directory` 
works as expected.