### PR TITLE
Trim left whitespace from Idris add-clause response

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -618,7 +618,7 @@ Otherwise, case split as a pattern variable."
         (command (if proof :add-proof-clause :add-clause)))
     (when (car what)
       (save-excursion (idris-load-file-sync))
-      (let ((result (car (idris-eval `(,command ,(cdr what) ,(car what)))))
+      (let ((result (string-trim-left (car (idris-eval `(,command ,(cdr what) ,(car what))))))
             final-point
             (prefix (save-excursion        ; prefix is the indentation to insert for the clause
                       (goto-char (point-min))

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -179,9 +179,9 @@ remain."
 
 (ert-deftest idris-test-idris-add-clause ()
   "Test that `idris-add-clause' generates definition with hole."
-  (let ((buffer (find-file "test-data/AddClause.idr"))
+  (let ((buffer (find-file-noselect "test-data/AddClause.idr"))
         (buffer-content (with-temp-buffer
-                          (insert-file-contents "AddClause.idr")
+                          (insert-file-contents "test-data/AddClause.idr")
                           (buffer-string))))
     (with-current-buffer buffer
       (goto-char (point-min))
@@ -195,6 +195,20 @@ remain."
       (goto-char (1+ (match-beginning 0)))
       (funcall-interactively 'idris-add-clause nil)
       (should (looking-at-p "(-) = \\?\\w+_rhs"))
+      (idris-delete-ibc t)
+
+      ;; Test that response with indentation (Idris2) are aligned correctly
+      ;; Idris1 response: "revAcc xs ys = ?revAcc_rhs"
+      ;; Idris2 response: "  revAcc xs ys = ?revAcc_rhs"
+      (goto-char (point-max))
+      (insert "
+myReverse : List a -> List a
+myReverse xs = revAcc [] xs where
+  revAcc : List a -> List a -> List a")
+      (search-backward "evAcc")
+      (funcall-interactively 'idris-add-clause nil)
+      (beginning-of-line)
+      (should (looking-at-p "^  revAcc xs ys = \\?revAcc_rhs"))
 
       ;; Cleanup
       (erase-buffer)


### PR DESCRIPTION
**Why:**
Idris2 returns generated string with indentation and as we compute the indentation ourself the result ends inserted with extra space.

**Before change** result of `idris-add-clause` on indented block in Idris2
![before-change-indent-add-clause](https://user-images.githubusercontent.com/578608/206936502-cb1d9c30-00c9-450e-92a9-8dc2abd44400.jpg)

**After change**
![after-change-indent-add-clause](https://user-images.githubusercontent.com/578608/206936510-58a9921b-9a5b-496f-8562-1ae44619a103.jpg)

(no change Idris1)