### PR TITLE
DRAFT: Update semantic highlighting implementation

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -40,7 +40,6 @@
 (require 'idris-prover)
 (require 'idris-common-utils)
 (require 'idris-syntax)
-(require 'idris-highlight-input)
 
 (require 'cl-lib)
 (require 'thingatpt)
@@ -106,6 +105,10 @@
                           result-msg)
           (progn
             (message result-msg)
+            ;; Allow per directory (project) semantic highlighting from Idris using .dir-locals.el .
+            ;; Example for turning it on:
+            ;; ((idris-mode . ((idris-semantic-source-highlighting . t))))
+            (toggle-semantic-highlighting)
             (setq idris-process-current-working-directory new-working-directory))
         (error "Failed to switch the working directory %s" eval-result)))))
 
@@ -213,7 +216,9 @@ A prefix argument SET-LINE forces loading but only up to the current line."
         ;; Actually do the loading
         (let* ((dir-and-fn (idris-filename-to-load))
                (fn (cdr dir-and-fn))
-               (srcdir (car dir-and-fn)))
+               (srcdir (car dir-and-fn))
+               (idris-semantic-source-highlighting (idris-buffer-semantic-source-highlighting)))
+          (toggle-semantic-highlighting)
           (setq idris-currently-loaded-buffer nil)
           (idris-switch-working-directory srcdir)
           (idris-delete-ibc t) ;; delete the ibc to avoid interfering with partial loads
@@ -223,8 +228,6 @@ A prefix argument SET-LINE forces loading but only up to the current line."
              `(:load-file ,fn))
            (lambda (result)
              (pcase result
-               (`(:highlight-source ,hs)
-                (idris-highlight-source-file hs))
                (_ (idris-make-clean)
                   (idris-update-options-cache)
                   (setq idris-currently-loaded-buffer (current-buffer))
@@ -276,7 +279,9 @@ This sets the load position to point, if there is one."
           (idris-load-to (point)))
         (let* ((dir-and-fn (idris-filename-to-load))
                (fn (cdr dir-and-fn))
-               (srcdir (car dir-and-fn)))
+               (srcdir (car dir-and-fn))
+               (idris-semantic-source-highlighting (idris-buffer-semantic-source-highlighting)))
+          (toggle-semantic-highlighting)
           (setq idris-currently-loaded-buffer nil)
           (idris-switch-working-directory srcdir)
           (let ((result

--- a/idris-highlight-input.el
+++ b/idris-highlight-input.el
@@ -60,37 +60,36 @@ See Info node `(elisp)Overlay Properties' to understand how ARGS are used."
   (if (or (> end-line start-line)
           (and (= end-line start-line)
                (> end-col start-col)))
-      (when idris-semantic-source-highlighting
-        (with-current-buffer buffer
-          (save-restriction
-            (widen)
-            (save-excursion
-              (goto-char (point-min))
-              (let* ((start-pos (+ (line-beginning-position start-line)
-                                   (idris-highlight-column start-col)))
-                     (end-pos (+ (line-beginning-position end-line)
-                                 (idris-highlight-column end-col)))
-                     (existing-idris-overlays-in-range (seq-filter
-                                                        (lambda (overlay)
-                                                          (overlay-get overlay 'idris-source-highlight))
-                                                        (overlays-in start-pos end-pos)))
-                     (existing-idris-overlay (seq-find (lambda (overlay)
-                                                         (and
-                                                          (eql start-pos (overlay-start overlay))
-                                                          (eql end-pos (overlay-end overlay))
-                                                          ;; TODO: overlay properties match
-                                                          ))
-                                                       existing-idris-overlays-in-range)))
-                (when (null existing-idris-overlay)
-                  (dolist (old-overlay existing-idris-overlays-in-range)
-                    (delete-overlay old-overlay))
-                  (let ((highlight-overlay (make-overlay start-pos end-pos)))
-                    (overlay-put highlight-overlay 'idris-source-highlight t)
-                    (idris-add-overlay-properties highlight-overlay
-                                                  (idris-semantic-properties highlight))
-                    (overlay-put highlight-overlay
-                                 'modification-hooks
-                                 '(idris-highlight--overlay-modification-hook)))))))))
+      (with-current-buffer buffer
+        (save-restriction
+          (widen)
+          (save-excursion
+            (goto-char (point-min))
+            (let* ((start-pos (+ (line-beginning-position start-line)
+                                 (idris-highlight-column start-col)))
+                   (end-pos (+ (line-beginning-position end-line)
+                               (idris-highlight-column end-col)))
+                   (existing-idris-overlays-in-range (seq-filter
+                                                      (lambda (overlay)
+                                                        (overlay-get overlay 'idris-source-highlight))
+                                                      (overlays-in start-pos end-pos)))
+                   (existing-idris-overlay (seq-find (lambda (overlay)
+                                                       (and
+                                                        (eql start-pos (overlay-start overlay))
+                                                        (eql end-pos (overlay-end overlay))
+                                                        ;; TODO: overlay properties match
+                                                        ))
+                                                     existing-idris-overlays-in-range)))
+              (when (null existing-idris-overlay)
+                (dolist (old-overlay existing-idris-overlays-in-range)
+                  (delete-overlay old-overlay))
+                (let ((highlight-overlay (make-overlay start-pos end-pos)))
+                  (overlay-put highlight-overlay 'idris-source-highlight t)
+                  (idris-add-overlay-properties highlight-overlay
+                                                (idris-semantic-properties highlight))
+                  (overlay-put highlight-overlay
+                               'modification-hooks
+                               '(idris-highlight--overlay-modification-hook))))))))
     (when (eq idris-semantic-source-highlighting 'debug)
       (message "Not highlighting absurd span %s:%s-%s:%s with %s"
                start-line start-col
@@ -123,6 +122,19 @@ See Info node `(elisp)Overlay Properties' to understand how ARGS are used."
                                              start-line start-col
                                              end-line end-col
                                              props))))))))
+
+(defun idris-syntax-higlight-event-hook-function (event)
+  (pcase event
+    (`(:output (:ok (:highlight-source ,hs)) ,_id)
+     (progn (idris-highlight-source-file hs) t))))
+
+(defun idris-syntax-higlight-event-noop-hook-function (event)
+  "Do nothing and return t when highlight source EVENT occur.
+
+Used when semantic highlighting is disabled using
+`idris-semantic-source-highlighting'."
+  (pcase event
+    (`(:output (:ok (:highlight-source ,_hs)) ,_id) t)))
 
 (provide 'idris-highlight-input)
 ;;; idris-highlight-input.el ends here

--- a/idris-highlight-input.el
+++ b/idris-highlight-input.el
@@ -105,24 +105,24 @@ See Info node `(elisp)Overlay Properties' to understand how ARGS are used."
             (:start ,start-line-raw ,start-col-raw)
             (:end ,end-line-raw ,end-col-raw))
            ,props)
-         (when (string= (file-name-nondirectory fn)
-                        (file-name-nondirectory (buffer-file-name)))
-           (let ((start-line (if (>=-protocol-version 2 1)
-                                 (1+ start-line-raw)
-                               start-line-raw))
-                 (start-col  (if (>=-protocol-version 2 1)
-                                 (1+ start-col-raw)
-                               start-col-raw))
-                 (end-line   (if (>=-protocol-version 2 1)
-                                 (1+ end-line-raw)
-                               end-line-raw))
-                 (end-col    (if (>= idris-protocol-version 1)
-                                 (1+ end-col-raw)
-                               end-col-raw)))
-             (idris-highlight-input-region (current-buffer)
-                                           start-line start-col
-                                           end-line end-col
-                                           props)))))))
+         (let ((buffer (get-file-buffer (expand-file-name fn idris-process-current-working-directory))))
+           (when buffer
+             (let ((start-line (if (>=-protocol-version 2 1)
+                                   (1+ start-line-raw)
+                                 start-line-raw))
+                   (start-col  (if (>=-protocol-version 2 1)
+                                   (1+ start-col-raw)
+                                 start-col-raw))
+                   (end-line   (if (>=-protocol-version 2 1)
+                                   (1+ end-line-raw)
+                                 end-line-raw))
+                   (end-col    (if (>= idris-protocol-version 1)
+                                   (1+ end-col-raw)
+                                 end-col-raw)))
+               (idris-highlight-input-region buffer
+                                             start-line start-col
+                                             end-line end-col
+                                             props))))))))
 
 (provide 'idris-highlight-input)
 ;;; idris-highlight-input.el ends here

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -71,6 +71,12 @@ If `debug', log failed highlighting to buffer `*Messages*'."
   :type '(choice (boolean :tag "Enable")
                  (const :tag "Debug" debug)))
 
+(defcustom idris-semantic-source-highlighting-max-buffer-size 32768 ;; (expt 2 15)
+  "Disable semantic source code highlighting if buffer exceds alloted size.
+This is to ensure that Emacs stays responsive for large Idris files."
+  :group 'idris
+  :type 'integer)
+
 (defcustom idris-log-events nil
   "If non-nil, communications between Emacs and Idris are logged.
 

--- a/idris-test-utils.el
+++ b/idris-test-utils.el
@@ -131,5 +131,26 @@ BODY is code to be executed within the temp buffer.  Point is
        ,@body)
      (sit-for 0.1)))
 
+;; Based on https://www.gnu.org/software/emacs/manual/html_node/ert/Fixtures-and-Test-Suites.html
+(defun with-idris-file-fixture (relative-filepath body &optional keep-idris-running wait)
+  (save-window-excursion
+    (let* ((buffer (find-file relative-filepath))
+           (buffer-content (buffer-substring-no-properties (point-min) (point-max))))
+      (unwind-protect
+          (progn (goto-char (point-min))
+                 (funcall body))
+
+        ;; Cleanup (Tear down)
+        ;; Usefull for manual inspection before restore
+        (when wait
+          (sit-for (or (and (numberp wait) wait) 10)))
+        (idris-delete-ibc t)
+        (erase-buffer)
+        (insert buffer-content)
+        (save-buffer)
+        (kill-buffer)
+        (when (not keep-idris-running)
+          (idris-quit))))))
+
 (provide 'idris-test-utils)
 ;;; idris-test-utils.el ends here

--- a/idris-tests.el
+++ b/idris-tests.el
@@ -289,6 +289,54 @@ myReverse xs = revAcc [] xs where
       (kill-buffer))
     (idris-quit)))
 
+(defun idris-buffer-contains-semantic-highlighting-p ()
+  (seq-find (lambda (overlay) (overlay-get overlay 'idris-source-highlight))
+             (overlays-in (point-min) (point-max))))
+
+(ert-deftest idris-semantic-highlighthing ()
+  (let ((idris-semantic-source-highlighting t))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-run)
+       (should (member 'idris-syntax-higlight-event-hook-function
+                       idris-event-hooks)))))
+  (let ((idris-semantic-source-highlighting nil))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-run)
+       (should (member 'idris-syntax-higlight-event-noop-hook-function
+                       idris-event-hooks)))))
+  (let ((idris-semantic-source-highlighting t))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-load-file)
+       (dotimes (_ 5) (accept-process-output nil 0.1))
+       (should (idris-buffer-contains-semantic-highlighting-p)))))
+  (let ((idris-semantic-source-highlighting t)
+        (idris-semantic-source-highlighting-max-buffer-size 8))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-load-file)
+       (dotimes (_ 5) (accept-process-output nil 0.1))
+       (should (not (idris-buffer-contains-semantic-highlighting-p))))))
+  (let ((idris-semantic-source-highlighting t))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-load-file-sync)
+       (should (idris-buffer-contains-semantic-highlighting-p)))))
+  (let ((idris-semantic-source-highlighting t)
+        (idris-semantic-source-highlighting-max-buffer-size 8))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-load-file-sync)
+       (should (not (idris-buffer-contains-semantic-highlighting-p)))))))
+
 (ert-deftest idris-backard-toplevel-navigation-test-2pTac9 ()
   "Test idris-backard-toplevel navigation command."
   (idris-test-with-temp-buffer

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -97,6 +97,27 @@ Set using file or directory variables.")
   "The list of `command-line-args' actually passed to Idris.
 This is maintained to restart Idris when the arguments change.")
 
+(defun toggle-semantic-highlighting ()
+  "Register appropriate syntax highlighting hook function.
+
+Which hook function is active is determinded by value of
+`idris-semantic-source-highlighting' variable."
+  (if idris-semantic-source-highlighting
+      (progn
+        (remove-hook 'idris-event-hooks 'idris-syntax-higlight-event-noop-hook-function)
+        (add-hook 'idris-event-hooks 'idris-syntax-higlight-event-hook-function))
+    (remove-hook 'idris-event-hooks 'idris-syntax-higlight-event-hook-function)
+    (add-hook 'idris-event-hooks 'idris-syntax-higlight-event-noop-hook-function)))
+
+(defun idris-buffer-semantic-source-highlighting ()
+  "Return nil if current buffer size is larger set limit.
+The limit is defined as value of:
+`idris-semantic-source-highlighting-max-buffer-size'.
+Otherwise return current value of `idris-semantic-source-highlighting'"
+  (and (< (buffer-size)
+          idris-semantic-source-highlighting-max-buffer-size)
+       idris-semantic-source-highlighting))
+
 (autoload 'idris-prover-event-hook-function "idris-prover.el")
 (autoload 'idris-quit "idris-commands.el")
 (defun idris-run ()
@@ -142,7 +163,6 @@ This is maintained to restart Idris when the arguments change.")
     (add-hook 'idris-event-hooks 'idris-log-hook-function)
     (add-hook 'idris-event-hooks 'idris-warning-event-hook-function)
     (add-hook 'idris-event-hooks 'idris-prover-event-hook-function)
-
     (unless idris-hole-show-on-load
       (remove-hook 'idris-load-file-success-hook 'idris-list-holes-on-load)
       (remove-hook 'idris-load-file-success-hook 'idris-list-holes)
@@ -150,7 +170,7 @@ This is maintained to restart Idris when the arguments change.")
       ;; idris-hole-show-on-load variable
       (remove-hook 'idris-prover-success-hook 'idris-list-holes-on-load)
       (remove-hook 'idris-prover-success-hook 'idris-list-holes))
-
+    (toggle-semantic-highlighting)
     (set-process-filter idris-connection 'idris-output-filter)
     (set-process-sentinel idris-connection 'idris-sentinel)
     (set-process-query-on-exit-flag idris-connection t)


### PR DESCRIPTION
This is initial work to make experience working in code with active semantic syntax highlighting better.
Open for discussion.
Goals: make it consistent and fast

Notes on work so far:
 - Remove depency of idris-commands.el on idris-highlight-input.el
 - Decouple file loading from syntax highlighting
 - Add guard for not try to highlight large idris files
 - Performance improvements (TODO: measure)
 - Allow per directory (project) enabled syntax semantic highlighting
   This may have positive impact on large codebases where the highlighting may cause interaction with Emacs/Idris
unresponsive.
  TODO: would be cool being able to tell also Idris not to generate the syntax highlighting