### PR TITLE
Improve semantic syntax highlighting

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -203,10 +203,12 @@ A prefix argument SET-LINE forces loading but only up to the current line."
         ;; Actually do the loading
         (let* ((dir-and-fn (idris-filename-to-load))
                (fn (cdr dir-and-fn))
-               (srcdir (car dir-and-fn)))
+               (srcdir (car dir-and-fn))
+               (idris-semantic-source-highlighting (idris-buffer-semantic-source-highlighting)))
           (setq idris-currently-loaded-buffer nil)
           (idris-switch-working-directory srcdir)
           (idris-delete-ibc t) ;; delete the ibc to avoid interfering with partial loads
+          (idris-toggle-semantic-source-highlighting)
           (idris-eval-async
            (if idris-load-to-here
                `(:load-file ,fn ,(idris-get-line-num idris-load-to-here))

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -344,8 +344,7 @@ and semantic annotations PROPS."
                (start-col-repl (+ input-col start-col))
                (end-line-repl (+ input-line end-line -1))
                (end-col-repl (+ input-col end-col)))
-          (idris-highlight-input-region buffer
-                                        start-line-repl start-col-repl
+          (idris-highlight-input-region start-line-repl start-col-repl
                                         end-line-repl end-col-repl
                                         props))))))
 

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -71,6 +71,12 @@ If `debug', log failed highlighting to buffer `*Messages*'."
   :type '(choice (boolean :tag "Enable")
                  (const :tag "Debug" debug)))
 
+(defcustom idris-semantic-source-highlighting-max-buffer-size 32768 ;; (expt 2 15)
+  "Disable semantic source highlighting if the buffer exceeds the allotted size.
+This is to reduce lag when loading large Idris files."
+  :group 'idris
+  :type 'integer)
+
 (defcustom idris-log-events nil
   "If non-nil, communications between Emacs and Idris are logged.
 

--- a/test/idris-test-utils.el
+++ b/test/idris-test-utils.el
@@ -133,5 +133,21 @@ BODY is code to be executed within the temp buffer.  Point is
        ,@body)
      (sit-for 0.1)))
 
+;; Based on https://www.gnu.org/software/emacs/manual/html_node/ert/Fixtures-and-Test-Suites.html
+(defun with-idris-file-fixture (relative-filepath body)
+  (save-window-excursion
+    (let* ((buffer (find-file relative-filepath))
+           (buffer-content (buffer-substring-no-properties (point-min) (point-max))))
+      (unwind-protect
+          (progn (goto-char (point-min))
+                 (funcall body))
+
+        ;; Cleanup (Tear down)
+        (idris-delete-ibc t)
+        (erase-buffer)
+        (insert buffer-content)
+        (save-buffer)
+        (kill-buffer)))))
+
 (provide 'idris-test-utils)
 ;;; idris-test-utils.el ends here

--- a/test/idris-test-utils.el
+++ b/test/idris-test-utils.el
@@ -133,21 +133,5 @@ BODY is code to be executed within the temp buffer.  Point is
        ,@body)
      (sit-for 0.1)))
 
-;; Based on https://www.gnu.org/software/emacs/manual/html_node/ert/Fixtures-and-Test-Suites.html
-(defun with-idris-file-fixture (relative-filepath body)
-  (save-window-excursion
-    (let* ((buffer (find-file relative-filepath))
-           (buffer-content (buffer-substring-no-properties (point-min) (point-max))))
-      (unwind-protect
-          (progn (goto-char (point-min))
-                 (funcall body))
-
-        ;; Cleanup (Tear down)
-        (idris-delete-ibc t)
-        (erase-buffer)
-        (insert buffer-content)
-        (save-buffer)
-        (kill-buffer)))))
-
 (provide 'idris-test-utils)
 ;;; idris-test-utils.el ends here

--- a/test/idris-tests.el
+++ b/test/idris-tests.el
@@ -134,6 +134,38 @@
       (idris-delete-ibc t)
       (kill-buffer))))
 
+(defun idris-buffer-contains-semantic-highlighting-p ()
+  (seq-find (lambda (overlay) (overlay-get overlay 'idris-source-highlight))
+            (overlays-in (point-min) (point-max))))
+
+(ert-deftest idris-semantic-highlighthing ()
+  (let ((idris-semantic-source-highlighting nil))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-load-file)
+       (dotimes (_ 5) (accept-process-output nil 0.1))
+       (should (not (idris-buffer-contains-semantic-highlighting-p))))))
+  (let ((idris-semantic-source-highlighting t))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-load-file)
+       (dotimes (_ 5) (accept-process-output nil 0.1))
+       (should (idris-buffer-contains-semantic-highlighting-p)))))
+  (let ((idris-semantic-source-highlighting t)
+        (idris-semantic-source-highlighting-max-buffer-size 8))
+    (with-idris-file-fixture
+     "test-data/AddClause.idr"
+     (lambda ()
+       (idris-load-file)
+       (dotimes (_ 5) (accept-process-output nil 0.1))
+       (should (not (idris-buffer-contains-semantic-highlighting-p)))
+       (with-current-buffer "*Messages*"
+         (should (string-match-p "Semantic source highlighting is disabled for the current buffer."
+                                 (buffer-substring-no-properties (point-min) (point-max))))))))
+  (idris-quit))
+
 (load "idris-commands-test")
 (load "idris-navigate-test")
 (load "idris-repl-test")


### PR DESCRIPTION

 - Correctly use `save-excursion` before `save-restriction` macro
 - Remove unnecessary `buffer` param from `idris-highlight-input-region`
 - Use `pcase-dolist` instead of `cl-loop & pcase`
 - Per buffer size controlled semantic source highlighting 
 - Decoupling debug mode for semantic highlighting from the default happy path

**Benchmark:**
Run twice with 5 and 10 repetitions
> The (x y z) represent list of the total elapsed time for execution, the number of garbage collections that ran, and the time taken by garbage collection.

**main** (before change)
;; 5 (4.345052 10 0.3808530000000001)
;; 10 (9.112914 21 0.8207839999999997)

**impro-sem-high** (after change)
;; idris-semantic-source-highlighting-max-buffer-size 32768
**;; 5 (4.123512 8 0.37952299999999894)
;; 10 (8.677349000000001 17 0.8196910000000006)**

;; idris-semantic-source-highlighting-max-buffer-size 9000 (snake/Main.idr loaded without highlighting)
;; 5 (3.922993 4 0.20145000000000124)
;; 10 (7.300091 9 0.45280699999999996)

Benchmark code:

```elisp
(require 'benchmark)
(defun idris-delete-source-highlight-overlays (buffer)
  (with-current-buffer buffer
    (mapc 'delete-overlay (seq-filter
                           (lambda (overlay)
                             (overlay-get overlay 'idris-source-highlight))
                           (overlays-in (point-min) (point-max))))))

(defun load-file-bench (b1 b2)
  (idris-delete-source-highlight-overlays b1)
  (idris-delete-source-highlight-overlays b2)
  (with-current-buffer b1
    (idris-load-file))
  (with-current-buffer b2
    (idris-load-file)))

;; to force change Idris working directory and reload the files 
;;we test load continuously 2 files in different dirs
(defun idris-run-file-load-benchmark (n f1 f2)
  (let ((b1 (find-file-noselect f1))
        (b2 (find-file-noselect f2)))
    (idris-delete-source-highlight-overlays b1)
    (idris-delete-source-highlight-overlays b2)
    (garbage-collect)
    (let ((idris-semantic-source-highlighting-max-buffer-size 9000))
      (benchmark-run-compiled n (load-file-bench b1 b2)))))

(idris-run-file-load-benchmark
 10
 "/ncurses-idris/examples/snake/Main.idr"
 "/ncurses-idris/examples/control_pumpkin/Main.idr")
```