### PR TITLE
Codebase improvements

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -77,7 +77,7 @@ Lisp package.")
     (when (and buf (buffer-live-p buf))
       (let ((win (get-buffer-window buf)))
         (kill-buffer buf)
-        (when (null (window-prev-buffers win))
+        (when (and (null (window-prev-buffers win)) (< 1 (length (window-list))))
           (delete-window win))))
     (when return-buffer (pop-to-buffer return-buffer `(display-buffer-reuse-window)))))
 

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -165,6 +165,7 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
   (pop-to-buffer (idris-repl-buffer))
   (goto-char (point-max)))
 
+(autoload 'idris-run "idris-commands.el")
 ;;;###autoload
 (defun idris-repl ()
   (interactive)

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -107,7 +107,10 @@ This is maintained to restart Idris when the arguments change.")
     (add-hook 'idris-event-hooks 'idris-warning-event-hook-function)
     (add-hook 'idris-event-hooks 'idris-prover-event-hook-function)
 
-    (unless idris-hole-show-on-load
+    (if idris-hole-show-on-load
+        (progn
+          (add-hook 'idris-load-file-success-hook 'idris-list-holes)
+          (add-hook 'idris-prover-success-hook 'idris-list-holes))
       (remove-hook 'idris-load-file-success-hook 'idris-list-holes-on-load)
       (remove-hook 'idris-load-file-success-hook 'idris-list-holes)
       ;; TODO: In future decouple prover sucess hook from being affected by

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -97,42 +97,6 @@ Set using file or directory variables.")
   "The list of `command-line-args' actually passed to Idris.
 This is maintained to restart Idris when the arguments change.")
 
-(autoload 'idris-prover-event-hook-function "idris-prover.el")
-(autoload 'idris-quit "idris-commands.el")
-(defun idris-run ()
-  "Run an inferior Idris process."
-  (interactive)
-  (let ((command-line-flags (idris-compute-flags)))
-    ;; Kill the running Idris if the command-line flags need updating
-    (when (and (get-buffer-process (get-buffer idris-connection-buffer-name))
-               (not (equal command-line-flags idris-current-flags)))
-      (message "Idris command line arguments changed, restarting Idris")
-      (idris-quit)
-      (sit-for 0.01)) ; allows the sentinel to run and reset idris-process
-    ;; Start Idris if necessary
-    (when (not idris-process)
-      (setq idris-process
-            (get-buffer-process
-             (apply #'make-comint-in-buffer
-                    "idris"
-                    idris-process-buffer-name
-                    idris-interpreter-path
-                    nil
-                    "--ide-mode-socket"
-                    command-line-flags)))
-      (with-current-buffer idris-process-buffer-name
-        (add-hook 'comint-preoutput-filter-functions
-                  'idris-process-filter
-                  nil
-                  t)
-        (add-hook 'comint-output-filter-functions
-                  'idris-show-process-buffer
-                  nil
-                  t))
-      (set-process-sentinel idris-process 'idris-sentinel)
-      (setq idris-current-flags command-line-flags)
-      (accept-process-output idris-process 3))))
-
 (defun idris-connect (port)
   "Establish a connection with a Idris REPL at PORT."
   (when (not idris-connection)


### PR DESCRIPTION

- Ensure restart of Idris connection takes into account change in `idris-hole-show-on-load` variable.
- Do not try delete last window when deleting Idris buffers
- Move interactive command `idris-run` from inferior-idris.el to idris-commands.el

Improves tests reliability and maintainability.
More details in individual commits.