### PR TITLE
Use `idris-case-dwim` in Idris menu instead of `idris-case-split` and `idris-make-cases-from-hole`

### DIFF
--- a/idris-mode.el
+++ b/idris-mode.el
@@ -79,10 +79,10 @@
     "-----------------"
     ["Add initial match clause to type declaration" idris-add-clause t]
     ["Add missing cases" idris-add-missing t]
-    ["Case split pattern variable" idris-case-split t]
+    ["Case split pattern variable" idris-case-dwim t]
     ["Add with block" idris-make-with-block t]
     ["Extract lemma from hole" idris-make-lemma t]
-    ["Solve hole with case expression" idris-make-cases-from-hole t]
+    ["Solve hole with case expression" idris-case-dwim t]
     ["Attempt to solve hole" idris-proof-search t]
     ["Get next solve attempt (Idris 2)" idris-proof-search-next t]
 


### PR DESCRIPTION

**Why:**
To display key binding which invokes desired command based on the point context in buffer.

**Resolves:**
https://github.com/idris-hackers/idris-mode/issues/447

**Before:**
![screen-2023-01-15-21-31-03](https://user-images.githubusercontent.com/578608/212568425-8c67bdbb-bdb5-4783-97e6-3f32dd256d19.jpg)

**After:**
![screen-2023-01-15-21-29-31](https://user-images.githubusercontent.com/578608/212568433-3723a3fe-69c5-409b-85bc-f3d02a789b4f.jpg)
