### PR TITLE
Add `idris-format` module with `idris-format-align-lhs` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ OBJS =	idris-commands.elc		\
 	idris-warnings-tree.elc		\
 	idris-xref.elc                  \
 	inferior-idris.elc              \
-	flycheck-idris.elc
+	flycheck-idris.elc              \
+	idris-format.elc
 
 .el.elc:
 	$(BYTECOMP) $<

--- a/idris-compat.el
+++ b/idris-compat.el
@@ -41,5 +41,51 @@ attention to case differences."
       (concat (apply 'concat (mapcar 'file-name-as-directory dirs))
               (car (reverse components))))))
 
+(if (fboundp 'string-limit)
+    (defalias 'idris-string-limit 'string-limit)
+  ;; Extracted from Emacs 28* 'subr-x
+  (defun idris-string-limit (string length &optional end coding-system)
+    "Return a substring of STRING that is (up to) LENGTH characters long.
+If STRING is shorter than or equal to LENGTH characters, return the
+entire string unchanged.
+
+If STRING is longer than LENGTH characters, return a substring
+consisting of the first LENGTH characters of STRING.  If END is
+non-nil, return the last LENGTH characters instead.
+
+If CODING-SYSTEM is non-nil, STRING will be encoded before
+limiting, and LENGTH is interpreted as the number of bytes to
+limit the string to.  The result will be a unibyte string that is
+shorter than LENGTH, but will not contain \"partial\" characters,
+even if CODING-SYSTEM encodes characters with several bytes per
+character.
+
+When shortening strings for display purposes,
+`truncate-string-to-width' is almost always a better alternative
+than this function."
+    (unless (natnump length)
+      (signal 'wrong-type-argument (list 'natnump length)))
+    (if coding-system
+        (let ((result nil)
+              (result-length 0)
+              (index (if end (1- (length string)) 0)))
+          (while (let ((encoded (encode-coding-char
+                                 (aref string index) coding-system)))
+                   (and (<= (+ (length encoded) result-length) length)
+                        (progn
+                          (push encoded result)
+                          (cl-incf result-length (length encoded))
+                          (setq index (if end (1- index)
+                                        (1+ index))))
+                        (if end (> index -1)
+                          (< index (length string)))))
+            ;; No body.
+            )
+          (apply #'concat (if end result (nreverse result))))
+      (cond
+       ((<= (length string) length) string)
+       (end (substring string (- (length string) length)))
+       (t (substring string 0 length))))))
+
 (provide 'idris-compat)
 ;;; idris-compat.el ends here

--- a/idris-format.el
+++ b/idris-format.el
@@ -1,0 +1,174 @@
+;;; idris-format.el --- Commands to format/prettify Idris code -*- lexical-binding: t -*-
+
+;; Copyright (C) 2023 Marek L.
+
+;; Author: Marek L. <nospam.keram@gmail.com>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;; Commands to prettify Idris code
+
+;;; Code:
+
+(require 'rx)
+(require 'subr-x)
+(require 'cl-seq)
+
+(defun idris-split-line-to-lhs-rhs (line)
+  "Split LINE string to two parts starting at first occurence of equal sign (=).
+The equal sign is part of the right hand side. If no equal sign found
+the `car' of result (LHS) is empty string and `cdr' of result (RHS) the LINE."
+  (let* ((lhs-length (or (string-match "=" line) 0))
+         (lhs (string-trim-right (string-limit line lhs-length)))
+         (rhs (substring line lhs-length)))
+    (cons lhs rhs)))
+
+(defun idris-mapcar-with-index (fn seq)
+  "Apply function FN to each element of SEQ, and make a list of the results.
+First argument to FN is element of SEQ and second its position in the SEQ."
+  (let ((i -1))
+    (mapcar (lambda (val)
+              (funcall fn val (cl-incf i)))
+            seq)))
+
+(defun idris-transpose-matrix (matrix)
+  "Convert MATRIX fro MxN to NxM elements."
+  (cl-labels ((trans-acc (m rows)
+                         (if (null (remove nil m))
+                             (reverse rows)
+                           (trans-acc (mapcar 'cdr m)
+                                      (cons (mapcar 'car m) rows)))))
+    (trans-acc matrix '())))
+
+(defun idris-parens-balanced-p (str)
+  "Return t if all parens in STR are balanced."
+  (eq (length (replace-regexp-in-string (rx (any "(" "[" "{")) "" str))
+      (length (replace-regexp-in-string (rx (any ")" "]" "}")) "" str))))
+
+(defun idris-max-words-lengths (split-lines)
+  "Return list of max lengths for each column in SPLIT-LINES."
+  (mapcar (lambda (words)
+            (apply #'max (mapcar #'length words)))
+          (idris-transpose-matrix split-lines)))
+
+(defun idris-split-words (str)
+  "Split string STR to list of words.
+As word is considered a sequence of non blank characters
+or expression inside parenthesis (including parenthesis)
+
+Example: (idris-split-words \"foo (S k) k\")
+ => '(\"foo\" \"(S k)\" \"k\")"
+  (let ((acc '())
+        (open '()))
+    (mapc
+     (lambda (word)
+       (if (null open)
+           (if (string-match "^[([{]" word)
+               (push word open)
+             (push word acc))
+         (push word open)
+         (and (idris-parens-balanced-p (string-join open))
+              (push (string-join (reverse open) " ") acc)
+              (setq open '())
+              (push word open))))
+     (split-string str))
+    (reverse acc)))
+
+(defun idris-pad-lines (lines)
+  "Return LINES with equal length of left hand side."
+  (let* ((prev-lhs-length)
+         (lhs-rhss
+          (mapcar (lambda (line)
+                    (if (and prev-lhs-length
+                             (< prev-lhs-length
+                                (- (length line) (length (string-trim-left line)))))
+                        (cons nil line)
+                      (let ((lhs-rhs (idris-split-line-to-lhs-rhs line)))
+                        (setq prev-lhs-length (length (car lhs-rhs)))
+                        lhs-rhs)))
+                  lines))
+         (lhss-words (mapcar #'idris-split-words (delq nil (mapcar #'car lhs-rhss))))
+         (mvl (idris-max-words-lengths lhss-words))
+         (prev-lhs-delta))
+    (mapcar
+     (lambda (lhs-rhs)
+       (if (and prev-lhs-delta (null (car lhs-rhs)))
+           (concat (make-string prev-lhs-delta ? ) (cdr lhs-rhs))
+         (let ((new-lhs (string-join (idris-mapcar-with-index (lambda (word j)
+                                                                (string-pad word (nth j mvl)))
+                                                              (car lhss-words))
+                                     " ")))
+           (setq prev-lhs-delta (- (length new-lhs) (length (car lhs-rhs))))
+           (setq lhss-words (cdr lhss-words))
+           (concat new-lhs " " (cdr lhs-rhs)))))
+     lhs-rhss)))
+
+(defun idris-end-of-clause ()
+  "Return position at the end of clause.
+
+As end of clause is considered end of non empty line before empty line
+or end of buffer."
+  (save-excursion
+    (condition-case _err
+        (progn
+          (re-search-forward (rx (or (and "\n" (zero-or-more blank) "\n")
+                                     string-end)))
+          (re-search-backward (rx (one-or-more not-newline)))
+          (line-end-position))
+      (error (user-error "End of clause not found")))))
+
+(defun idris-beginning-of-clause ()
+  "Return position at the end of clause.
+
+As beginning of clause is considered beginning of top most line
+before line containing colon symbol (:) that contains equal sign (=)."
+  (save-excursion
+    (condition-case _err
+        (progn
+          (re-search-backward ":")
+          (re-search-forward "=")
+          (beginning-of-line)
+          (skip-chars-forward " \t")
+          (point))
+      (error (user-error "Beginning of clause not found")))))
+
+(defun idris-clause-point-column (point)
+  "Return column of the POINT."
+  (save-excursion
+    (goto-char point)
+    (current-column)))
+
+;; Maybe we could leverage existing `align' library?
+(defun idris-format-align-lhs ()
+  "Align LHS of function definition."
+  (interactive)
+  (let ((init-position (point)))
+    (beginning-of-line)
+    (let* ((start (idris-beginning-of-clause))
+           (end (idris-end-of-clause))
+           (indent (make-string (idris-clause-point-column start) ? ))
+           (lines (string-lines (buffer-substring-no-properties start end)))
+           (padded-lines (mapcar (lambda (line) (concat indent line))
+                                 (idris-pad-lines lines)))
+           (new-region (string-join padded-lines "\n")))
+      (goto-char start)
+      (beginning-of-line)
+      (delete-region (point) end)
+      (insert new-region)
+      (goto-char init-position))))
+
+(provide 'idris-format)
+
+;;; idris-format.el ends here

--- a/idris-mode.el
+++ b/idris-mode.el
@@ -30,6 +30,7 @@
 (require 'idris-common-utils)
 (require 'idris-ipkg-mode)
 (require 'idris-xref)
+(require 'idris-format)
 
 (defun idris-mode-context-menu-items (plist)
   "Compute menu items from PLIST that are specific to editing text in `idris-mode'."

--- a/test/idris-format-test.el
+++ b/test/idris-format-test.el
@@ -1,0 +1,198 @@
+;;; idris-format-test.el --- Tests for prettify-ing commands of Idris code -*- lexical-binding: t -*-
+
+;; Copyright (C) 2023 Marek L.
+
+;; Author: Marek L. <nospam.keram@gmail.com>
+
+;; License:
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Collection of tests for interactive commands to prettify Idris source code
+
+;;; Code:
+
+(let ((test-dir (file-name-directory (or load-file-name (buffer-file-name)))))
+  (add-to-list 'load-path test-dir)
+  ;; In batch mode default dir points to ../ and causing issues with saving
+  ;; Idris fixtures so we set it to the test-dir to avoid the issues.
+  (setq default-directory test-dir))
+
+(require 'idris-format)
+(require 'ert)
+(require 'cl-lib)
+
+(defun idris-buffer-content ()
+  (buffer-substring-no-properties (point-min) (point-max)))
+
+(ert-deftest idris-format-align-lhs ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat -> Nat -> Nat"
+                                  "minus 0 j = ?minus_rhs_0"
+                                  "minus (S k) j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat -> Nat -> Nat"
+                                   "minus 0     j = ?minus_rhs_0"
+                                   "minus (S k) j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "0"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(ert-deftest idris-format-align-lhs-with-point-at-end-of-the-clause ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat -> Nat -> Nat"
+                                  "minus 0 j = ?minus_rhs_0"
+                                  "minus (S k) j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat -> Nat -> Nat"
+                                   "minus 0     j = ?minus_rhs_0"
+                                   "minus (S k) j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "rhs_1"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(ert-deftest idris-format-align-lhs-with-point-at-beginning-of-clause ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat -> Nat -> Nat"
+                                  "minus 0 j = ?minus_rhs_0"
+                                  "minus (S k) j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat -> Nat -> Nat"
+                                   "minus 0     j = ?minus_rhs_0"
+                                   "minus (S k) j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "0"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (beginning-of-line)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(ert-deftest idris-format-align-lhs-with-point-at-second-line-with-multiline-type-definition ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat"
+                                  "  -> Nat"
+                                  "  -> Nat"
+                                  "minus 0 j = ?minus_rhs_0"
+                                  "minus (S k) j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat"
+                                   "  -> Nat"
+                                   "  -> Nat"
+                                   "minus 0     j = ?minus_rhs_0"
+                                   "minus (S k) j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "0"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (beginning-of-line)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(ert-deftest idris-format-align-lhs-indented ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat -> Nat -> Nat"
+                                  "  minus 0 j = ?minus_rhs_0"
+                                  "  minus (S k) j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat -> Nat -> Nat"
+                                   "  minus 0     j = ?minus_rhs_0"
+                                   "  minus (S k) j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "0"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (beginning-of-line)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(ert-deftest idris-format-align-lhs-with-multiline-rhs ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat -> Nat -> Nat"
+                                  "minus 0 j = case j < 3 of"
+                                  "                 False => ?minus_rhs_2"
+                                  "                 True => ?minus_rhs_3"
+                                  "minus (S k) j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat -> Nat -> Nat"
+                                   "minus 0     j = case j < 3 of"
+                                   "                     False => ?minus_rhs_2"
+                                   "                     True => ?minus_rhs_3"
+                                   "minus (S k) j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "case"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(ert-deftest idris-format-align-lhs-with-nested-parenthesis ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat -> Nat -> Nat"
+                                  "minus 0 j = ?minus_rhs_0"
+                                  "minus (T (S k) (S l)) j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat -> Nat -> Nat"
+                                   "minus 0               j = ?minus_rhs_0"
+                                   "minus (T (S k) (S l)) j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "0"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(ert-deftest idris-format-align-lhs-with-square-brackets ()
+  (with-temp-buffer
+    (let ((payload (string-join '("minus : Nat -> Nat -> Nat"
+                                  "minus 0 j = ?minus_rhs_0"
+                                  "minus [T (S k), (S l)] j = ?minus_rhs_1")
+                                "\n"))
+          (expected (string-join '("minus : Nat -> Nat -> Nat"
+                                   "minus 0                j = ?minus_rhs_0"
+                                   "minus [T (S k), (S l)] j = ?minus_rhs_1")
+                                 "\n"))
+          (position-re "0"))
+      (erase-buffer)
+      (insert payload)
+      (goto-char (point-min))
+      (re-search-forward position-re)
+      (idris-format-align-lhs)
+      (should (string-equal expected (idris-buffer-content))))))
+
+(provide 'idris-format-test)
+
+;;; idris-format-test.el ends here

--- a/test/idris-tests.el
+++ b/test/idris-tests.el
@@ -184,6 +184,7 @@
 (load "idris-repl-test")
 (load "idris-xref-test")
 (load "idris-info-test")
+(load "idris-format-test")
 
 (provide 'idris-tests)
 ;;; idris-tests.el ends here


### PR DESCRIPTION
**Why:**
Sometimes it makes nicer to align left hand side to columns.

**Demo:**

![output-2023-02-02-19:16:59](https://user-images.githubusercontent.com/578608/216430809-912b6df2-b6a7-4eaa-8e12-5d9cc900f4f5.gif)



![output-2023-02-02-19:19:45](https://user-images.githubusercontent.com/578608/216430822-be7fe4cb-8a84-468f-be6d-4e7b37241751.gif)


This is first version and as next step it could be nice generalise the solution for aligning different types  left hands sides.
Also not sure if this should live in idris-mode or rather as separate package 🤔 