### PR TITLE
Ensure that argument passed to idris-repl-insert-result is a string

### DIFF
--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -47,7 +47,7 @@
   "Working directory of Idris process.")
 
 (defvar idris-command-line-option-functions nil
-  "A list of functions to call to compute the 'command-line' arguments to Idris.
+  "A list of functions to call to compute the `command-line' arguments to Idris.
 Each function should take no arguments and return a list of
 strings that are suitable arguments to `start-process'.")
 

--- a/idris-highlight-input.el
+++ b/idris-highlight-input.el
@@ -118,8 +118,8 @@ See Info node `(elisp)Overlay Properties' to understand how ARGS are used."
 
 (defun idris-toggle-semantic-source-highlighting ()
   "Turn on/off semantic highlighting.
-This is controled by value of`idris-semantic-source-highlighting' variable.
-When the value is 'debug additional checks are performed on received data."
+This is controled by value of `idris-semantic-source-highlighting' variable.
+When the value is `debug' additional checks are performed on received data."
   (if idris-semantic-source-highlighting
       (progn
         (if (eq idris-semantic-source-highlighting 'debug)

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -276,7 +276,22 @@ Invokes `idris-repl-mode-hook'."
      t)
     (`(:warning ,output ,_target)
      (when (member 'warnings-repl idris-warnings-printing)
-       (idris-repl-write-string (format "Error: %s line %d (col %d):\n%s" (nth 0 output) (nth 1 output) (if (eq (safe-length output) 3) 0 (nth 2 output)) (car (last output))))))
+       (pcase output
+         (`(,fname (,start-line ,start-col) (,_end-line ,_end-col) ,msg ,_spans)
+          (idris-repl-write-string (format "Error: %s line %d (col %d):\n%s"
+                                           fname
+                                           (1+ start-line)
+                                           (1+ start-col)
+                                           msg)))
+         ;; Keeping this old format for backward compatibility.
+         ;; Probably we can remove it at some point.
+         (_ (idris-repl-write-string (format "Error: %s line %d (col %d):\n%s"
+                                             (nth 0 output)
+                                             (nth 1 output)
+                                             (if (eq (safe-length output) 3)
+                                                 0
+                                               (nth 2 output))
+                                             (car (last output))))))))
     (`(:run-program ,file ,_target)
      (idris-execute-compiled-program file))
     (_ nil)))

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -390,7 +390,7 @@ and semantic annotations PROPS."
                  ,props)
                (idris-repl-highlight-input
                 start start-line start-col end-line end-col props))))))
-       (_ (idris-repl-insert-result result spans)))) ;; The actual result
+       (_ (idris-repl-insert-result (or result "") spans)))) ;; The actual result
     ((:error condition &optional spans)
      (idris-repl-show-abort condition spans))))
 

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -497,7 +497,7 @@ highlighting information from Idris."
 
 (defun idris-repl-history-replace (direction)
   "Replace the current input with the next line in DIRECTION.
-DIRECTION is 'forward' or 'backward' (in the history list)."
+DIRECTION is `forward' or `backward' (in the history list)."
   (let* ((min-pos -1)
          (max-pos (length idris-repl-input-history))
          (prefix (idris-repl-history-prefix))

--- a/idris-settings.el
+++ b/idris-settings.el
@@ -342,7 +342,7 @@ using Idris2, then you may wish to customise this variable."
 
 (defcustom idris-repl-prompt-style 'short
   "What sort of prompt to show.
-'long shows the Idris REPL prompt, while 'short shows a shorter one."
+`long' shows the Idris REPL prompt, while `short' shows a shorter one."
   :options '(short long)
   :type 'symbol
   :group 'idris-repl)

--- a/test/idris-xref-test.el
+++ b/test/idris-xref-test.el
@@ -193,7 +193,8 @@
     (with-current-buffer "*xref*"
       ;; Assert
       (let ((str (buffer-substring-no-properties (point-min) (point-max))))
-        (should (string-match-p "11: AddClause.(-)" str))
+        (should (string-match-p "AddClause.(-)" str))
+        (should (string-match-p "11:" str))
         (should (string-match-p "AddClause.idr" str))
         (should (string-match-p "Prelude.Num.(-)" str))
         (should (string-match-p "prim__lte_Bits64" str)))


### PR DESCRIPTION
**Why:**
Interpreting command `:load "Foo.idr"` produces output `(:ok nil)` from Idris.
This leads to error `(wrong-type-argument char-or-string-p nil)`

Fixes https://github.com/idris-hackers/idris-mode/issues/620

This PR also includes additional minor fixes for issues discovered in the process of fixing the #620 

