### PR TITLE
Add quotes around sourcedir value in generated .ipkg file

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -1275,7 +1275,7 @@ of the term to replace."
     (newline)
     (insert "opts = \"\"")
     (newline)
-    (when src-dir (insert "sourcedir = " src-dir) (newline))
+    (when src-dir (insert "sourcedir = \"" src-dir "\"") (newline))
     (insert "modules = ")
     (insert first-mod)
     (newline)


### PR DESCRIPTION
Resolves: https://github.com/idris-hackers/idris-mode/issues/622