### PR TITLE
[ ci ] prune workflows for Idris1

### DIFF
--- a/.github/workflows/idris1.yml
+++ b/.github/workflows/idris1.yml
@@ -19,8 +19,8 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        emacs: [25.3, 26.1, 27.2, 28.2]
-        idris: [git, stackage]
+        emacs: [28.2]
+        idris: [git]
     env:
       EMACS_VERSION: ${{ matrix.emacs }}
       IDRIS_VERSION: ${{ matrix.idris }}

--- a/.github/workflows/idris2.yml
+++ b/.github/workflows/idris2.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        emacs: [25.3, 26.3, 27.2, 28.2]
+        emacs: [27.2, 28.2, 29.3]
 
     env:
       EMACS_VERSION: ${{ matrix.emacs }}


### PR DESCRIPTION
For all intents and purposes, Idris1 is no longer being actively developed. We should nonetheless keep an eye on `idris-mode` working with the *latest* versions of Idris1 and Emacs.