### PR TITLE
Improve `idris-filename-to-load` to return  expected pair of dir and relative path depending on idris-protocol version

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -168,14 +168,14 @@
 (defun idris-filename-to-load ()
   "Compute the working directory and filename to load in Idris.
 Returning these as a cons."
-  (let* ((fn (buffer-file-name))
-         (ipkg-srcdir (idris-ipkg-find-src-dir))
-         (srcdir (or ipkg-srcdir (file-name-directory fn))))
-    (when (and  ;; check that srcdir is prefix of filename - then load relative
-           (> (length fn) (length srcdir))
-           (string= (substring fn 0 (length srcdir)) srcdir))
-      (setq fn (file-relative-name fn srcdir)))
-    (cons srcdir fn)))
+  (let* ((ipkg-file (car-safe (idris-find-file-upwards "ipkg")))
+         (file-name (buffer-file-name))
+         (work-dir (directory-file-name (idris-file-name-parent-directory (or ipkg-file file-name))))
+         (source-dir (or (idris-ipkg-find-src-dir) work-dir)))
+    ;; TODO: Update once https://github.com/idris-lang/Idris2/issues/3310 is resolved
+    (if (> idris-protocol-version 1)
+        (cons work-dir (file-relative-name file-name work-dir))
+      (cons source-dir (file-relative-name file-name source-dir)))))
 
 (defun idris-load-file (&optional set-line)
   "Pass the current buffer's file to the inferior Idris process.

--- a/idris-compat.el
+++ b/idris-compat.el
@@ -41,5 +41,28 @@ attention to case differences."
       (concat (apply 'concat (mapcar 'file-name-as-directory dirs))
               (car (reverse components))))))
 
+(if (fboundp 'file-name-parent-directory)
+    (defalias 'idris-file-name-parent-directory 'file-name-parent-directory)
+  ;; Extracted from Emacs 29+ https://github.com/emacs-mirror/emacs/blob/master/lisp/files.el
+  (defun idris-file-name-parent-directory (filename)
+    "Return the directory name of the parent directory of FILENAME.
+If FILENAME is at the root of the filesystem, return nil.
+If FILENAME is relative, it is interpreted to be relative
+to `default-directory', and the result will also be relative."
+    (let* ((expanded-filename (expand-file-name filename))
+           (parent (file-name-directory (directory-file-name expanded-filename))))
+      (cond
+       ;; filename is at top-level, therefore no parent
+       ((or (null parent)
+            ;; `equal' is enough, we don't need to resolve symlinks here
+            ;; with `file-equal-p', also for performance
+            (equal parent expanded-filename))
+        nil)
+       ;; filename is relative, return relative parent
+       ((not (file-name-absolute-p filename))
+        (file-relative-name parent))
+       (t
+        parent)))))
+
 (provide 'idris-compat)
 ;;; idris-compat.el ends here


### PR DESCRIPTION
### What:
Make `(idris-filename-to-load)` to return
- a "source dir" and "relative file path" when source dir is exctracted from ipkg file.
- a "work dir" (parent directory containing a ipkg file) and "relative file path" when Idris protocol version is greater than 1.
- a "parent directory" and "file" when no ipkg file found

### Why:
In Idris2 the files are loaded relative to work directory which is a directory containing an ".ipkg" file.
This will allow us reintroduce regexp to correctly extract sourcedir value from ipkg file in Idris2.

Relates to:
https://github.com/idris-lang/Idris2/issues/3310
https://github.com/idris-hackers/idris-mode/pull/627