### PR TITLE
Specify `--` as comment syntax for ipkg mode

### DIFF
--- a/idris-ipkg-mode.el
+++ b/idris-ipkg-mode.el
@@ -422,7 +422,8 @@ Invokes `idris-ipkg-mode-hook'."
   (set (make-local-variable 'font-lock-defaults)
        idris-ipkg-font-lock-defaults)
   (set (make-local-variable 'completion-at-point-functions)
-       '(idris-ipkg-complete-keyword)))
+       '(idris-ipkg-complete-keyword))
+  (set (make-local-variable 'comment-start) "--"))
 
 ;; Make filenames clickable
 (add-to-list 'compilation-error-regexp-alist-alist


### PR DESCRIPTION
Why:
To avoid prompt when executing `comment-*` function in `*.ipkg` file.
```
comment-normalize-vars: No comment syntax defined
```