### PR TITLE
Make so `idris-identifier-face` doesn't explicitly inherit from the `default` face

### DIFF
--- a/CHANGES.markdown
+++ b/CHANGES.markdown
@@ -32,6 +32,7 @@ with release 0.9.19.
 
 ### Bug fixes
 
++ Fix `idris-identifier-face` looking wrong in `org-mode` blocks and the like.
 + [3c3a87c66c](https://github.com/idris-hackers/idris-mode/commit/3c3a87c66c): Fix failure to find beginning of function type definition when lifting hole and function name contains underscore.
 + [62c3ad2b0d](https://github.com/idris-hackers/idris-mode/commit/62c3ad2b0d): Do not display unnecessary `*idris-process*` buffer when loading file.
 + [486be1b740](https://github.com/idris-hackers/idris-mode/commit/486be1b740): Improve `idris-case-dwim` to make case expression from hole in edge case point positions.

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -49,3 +49,4 @@ Yasu Watanabe
 defanor
 startling
 κeen
+identity

--- a/idris-syntax.el
+++ b/idris-syntax.el
@@ -34,7 +34,7 @@ contributing the settings upstream to the theme maintainer."
   :prefix 'idris :group 'idris)
 
 (defface idris-identifier-face
-  '((t (:inherit default)))
+  '((t nil))
   "The face to highlight Idris identifiers with."
   :group 'idris-faces)
 


### PR DESCRIPTION
All faces implicitly inherit from the `default` face, and doing so explicitly can mess up font-lock unexpectedly in some places (like org-mode code blocks).