### PR TITLE
Improve user experience of `idris-switch-to-repl` command

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -251,9 +251,11 @@ A prefix argument SET-LINE forces loading but only up to the current line."
         (goto-char (overlay-end (car warnings-backward)))
       (user-error "No warnings or errors until beginning of buffer"))))
 
-(defun idris-load-file-sync ()
+(defun idris-load-file-sync (&optional no-errors)
   "Pass the current buffer's file synchronously to the inferior Idris process.
-This sets the load position to point, if there is one."
+This sets the load position to point, if there is one.
+
+If NO-ERRORS is passed the warnings from Idris will be ignored."
   (save-buffer)
   (idris-ensure-process-and-repl-buffer)
   (if (buffer-file-name)
@@ -274,11 +276,15 @@ This sets the load position to point, if there is one."
                  (idris-eval
                   (if idris-load-to-here
                       `(:load-file ,fn ,(idris-get-line-num idris-load-to-here))
-                    `(:load-file ,fn))))
+                    `(:load-file ,fn))
+                  no-errors))
                 (idris-currently-loaded-buffer (current-buffer)))
-            (idris-update-options-cache)
-            (idris-make-clean)
-            (idris-update-loaded-region (car result)))))
+            ;; Currently on success the result contains `(nil)`, on failure just nil
+            (if (and no-errors (null result))
+                (message "Failed to load current file into Idris")
+              (idris-update-options-cache)
+              (idris-make-clean)
+              (idris-update-loaded-region (car result))))))
     (user-error "Cannot find file for current buffer")))
 
 

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -186,9 +186,12 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
       (idris-repl-insert-prompt)
       (insert current-input))))
 
+(autoload 'idris-load-file-sync "idris-commands.el")
+;;;###autoload
 (defun idris-switch-to-repl ()
-  "Select the output buffer and scroll to bottom."
-  (interactive)
+  "Load the current Idris file buffer and jump to the Idris REPL."
+  (interactive nil idris-mode)
+  (idris-load-file-sync)
   (pop-to-buffer (idris-repl-buffer))
   (goto-char (point-max)))
 
@@ -199,7 +202,8 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
 (defun idris-repl ()
   (interactive)
   (idris-run)
-  (idris-switch-to-repl))
+  (pop-to-buffer (idris-repl-buffer))
+  (goto-char (point-max)))
 
 (defvar idris-repl-mode-map
   (let ((map (make-sparse-keymap)))

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -191,7 +191,7 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
 (defun idris-switch-to-repl ()
   "Load the current Idris file buffer and jump to the Idris REPL."
   (interactive nil idris-mode)
-  (idris-load-file-sync)
+  (idris-load-file-sync t)
   (pop-to-buffer (idris-repl-buffer))
   (goto-char (point-max)))
 

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -188,10 +188,16 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
 
 (autoload 'idris-load-file-sync "idris-commands.el")
 ;;;###autoload
-(defun idris-switch-to-repl ()
-  "Load the current Idris file buffer and jump to the Idris REPL."
-  (interactive nil idris-mode)
-  (idris-load-file-sync t)
+(defun idris-switch-to-repl (&optional load-file)
+  "Switch to the Idris REPL buffer.
+
+When executed in Idris file and LOAD-FILE is non-nil,
+the current file will be loaded  into Idris before switching.
+Errors during file loading are ignored."
+  (interactive "P")
+  (if (and (derived-mode-p 'idris-mode) load-file)
+        (idris-load-file-sync t)
+      (idris-run))
   (pop-to-buffer (idris-repl-buffer))
   (goto-char (point-max)))
 

--- a/idris-repl.el
+++ b/idris-repl.el
@@ -186,20 +186,37 @@ If ALWAYS-INSERT is non-nil, always insert a prompt at the end of the buffer."
       (idris-repl-insert-prompt)
       (insert current-input))))
 
+(defcustom idris-x-switch-to-repl-copy-region t
+  "*Experimental*
+When using the `idris-switch-to-repl' command with an active region,
+copy the region and paste it into the REPL.
+This copy does not modify the user's kill ring."
+  :group 'idris
+  :type 'boolean)
+
 (autoload 'idris-load-file-sync "idris-commands.el")
 ;;;###autoload
 (defun idris-switch-to-repl (&optional load-file)
   "Switch to the Idris REPL buffer.
 
-When executed in Idris file and LOAD-FILE is non-nil,
-the current file will be loaded  into Idris before switching.
-Errors during file loading are ignored."
+If called from an Idris file and LOAD-FILE is non-nil,
+load the current file into the REPL before switching.
+Errors during file loading are ignored.
+
+*Experimental*
+When feature flag `idris-x-switch-to-repl-copy-region' is enabled
+and there is an active region, paste the region into the REPL."
   (interactive "P")
-  (if (and (derived-mode-p 'idris-mode) load-file)
-        (idris-load-file-sync t)
-      (idris-run))
-  (pop-to-buffer (idris-repl-buffer))
-  (goto-char (point-max)))
+  (let ((region (if (and idris-x-switch-to-repl-copy-region (use-region-p))
+                    (buffer-substring-no-properties
+                     (region-beginning) (region-end)))))
+    (idris-run)
+    (when (and (derived-mode-p 'idris-mode) load-file)
+      (idris-load-file-sync t))
+    (pop-to-buffer (idris-repl-buffer))
+    (goto-char (point-max))
+    (when region
+      (insert region))))
 
 (define-obsolete-function-alias 'idris-switch-to-output-buffer 'idris-switch-to-repl "2022-12-28")
 


### PR DESCRIPTION
After testing these changes locally for some time, stabilised the changes to:

- load current visiting Idris buffer file if `idris-switch-to-repl` is executed with prefix
  Example: `C-- C-c C-z`
  This aligns with similar behaviour of other languages in Emacs particularly clojure (cider).
  The loading is performed synchronuosly and optimistically, with errors being ignored.

- If active region paste region into the REPL

  This makes experimentation with code simpler.
