### PR TITLE
Update CI Emacs versions to last 3 current major releases

### DIFF
--- a/.github/workflows/idris1.yml
+++ b/.github/workflows/idris1.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        emacs: [29.3]
+        emacs: [30.2]
         idris: [git]
     env:
       EMACS_VERSION: ${{ matrix.emacs }}

--- a/.github/workflows/idris2.yml
+++ b/.github/workflows/idris2.yml
@@ -30,7 +30,7 @@ jobs:
 
     strategy:
       matrix:
-        emacs: [27.2, 28.2, 29.3]
+        emacs: [28.2, 29.4, 30.2]
 
     env:
       EMACS_VERSION: ${{ matrix.emacs }}


### PR DESCRIPTION
Why:
Moving to support last 3 major releases will help us improve maintainability by removing need for maintaining backward compatible code.

Example:
https://github.com/idris-hackers/idris-mode/issues/645