### PR TITLE
Hide notes buffer whe no notes available

### DIFF
--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -38,18 +38,19 @@
 (defvar idris-tree-printer 'idris-tree-default-printer)
 
 (defun idris-compiler-notes-list-show (notes)
-  (if (null notes)
-      nil ;; See https://github.com/idris-hackers/idris-mode/pull/148 TODO: revisit
-    (with-current-buffer (get-buffer-create idris-notes-buffer-name)
-      (idris-compiler-notes-mode)
-      (let ((buffer-read-only nil)
-            (root (idris-compiler-notes-to-tree notes)))
-        (erase-buffer)
+  (with-current-buffer (get-buffer-create idris-notes-buffer-name)
+    (idris-compiler-notes-mode)
+    (let ((inhibit-read-only t)
+          (window (get-buffer-window))
+          (root (idris-compiler-notes-to-tree notes)))
+      (erase-buffer)
+      (if (null notes)
+          (when window (quit-window nil window))
         (idris-tree-insert root "")
         (insert "\n\n")
         (message "Press q to close, return or mouse on error to navigate to source")
-        (goto-char (point-min))))
-    (display-buffer idris-notes-buffer-name)))
+        (goto-char (point-min))
+        (display-buffer idris-notes-buffer-name)))))
 
 (defun idris-tree-for-note (note)
   (let* ((buttonp (> (length (nth 0 note)) 0)) ;; if empty source location


### PR DESCRIPTION
This revisits https://github.com/idris-hackers/idris-mode/pull/148 and improves the user experience when Idris does not report any errors.

Previously in such case the user is left with empty buffer in some of the windows. After this change if there is nothing to display the window the notes either display previous buffer or it is closed completely if notes buffer was the only buffer displayed in it.

Example:
- single window

![output-2025-11-16-00:31:14](https://github.com/user-attachments/assets/f0f89e7a-dd55-4e63-bde7-ca0033f189d3)

- two existing windows

![output-2025-11-16-00:31:54](https://github.com/user-attachments/assets/250be03c-8cb9-4dc4-b34b-ab3e538327ad)
