### PR TITLE
Add fallback for Idris2 to use :type-of for eldoc-lookup

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -501,8 +501,24 @@ Considered as a global variable"
       (idris-info-for-name :docs-for name))))
 
 (defun idris-eldoc-lookup ()
-  "Return Eldoc string associated with the thing at point."
-  (get-char-property (point) 'idris-eldoc))
+  "Return Eldoc string associated with the thing at point.
+
+(Idris2)
+If no valid Eldoc string is present and an active Idris process exist
+ retrieve a type of the thing at point instead."
+  (let ((prop-val (get-char-property (point) 'idris-eldoc)))
+    (if (and idris-process (stringp prop-val) (string-suffix-p ": " prop-val))
+        (let* ((thing (idris-name-at-point))
+               (ty (idris-eval (list :type-of thing) t))
+               (result (car ty))
+               (formatting (cdr ty))
+               (result-colour (idris-propertize-str (idris-repl-semantic-text-props formatting)
+                                                    result)))
+          (dolist (overlay (overlays-at (point)))
+            (when (overlay-get overlay 'idris-source-highlight)
+              (overlay-put overlay 'idris-eldoc result-colour)))
+          result-colour)
+      prop-val)))
 
 (defun idris-pretty-print ()
   "Get a term or definition pretty-printed by Idris.

--- a/idris-common-utils.el
+++ b/idris-common-utils.el
@@ -123,6 +123,13 @@ inserted text (that is, relative to point prior to insertion)."
                                           (+ ,start begin length)
                                           props))))))
 
+(defun idris-propertize-str (spans text)
+  "Add properties indicated by SPANS to the TEXT.
+SPANS is a list of (BEGIN LENGTH PROPERTIES) elements."
+  (dolist (span spans text)
+    (cl-destructuring-bind (begin length props) span
+      (set-text-properties begin (+ begin length) props text))))
+
 ;;; TODO: Take care of circular dependency issue
 (autoload 'idris-eval "inferior-idris.el")
 
@@ -223,7 +230,6 @@ inserted text (that is, relative to point prior to insertion)."
           (namespace (list 'idris-eldoc
                            (cadr namespace)))
           (t nil))))
-
 
 (defun idris-semantic-properties-help-echo (props)
   (let* ((name (assoc :name props))


### PR DESCRIPTION
Why:
Idris2 IDE mode is lacking implementation of `doc-overview` attribute used in Idris 1 to display the short doc in minibuffer.

This may be temporary until Idris2 implementation is updated.

Before:
![eldoc-idris2-screen-before](https://github.com/user-attachments/assets/01749560-33cf-4e65-9651-47b79bc6eb45)

After:
![eldoc-idris2-screen](https://github.com/user-attachments/assets/69e31211-3284-4436-9f33-ecef5b2569e8)

Will keep this open as draft for while to test if there will be possible performance implications and open for feedback.
Of course best would be to to do changes in the idris2 itself but other's may consider this also useful meanwhile. 
