### PR TITLE
Move call to idris-list-compiler-notes from idris-eval to new helper function idris-user-eval

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -271,7 +271,7 @@ This sets the load position to point, if there is one."
           (idris-switch-working-directory srcdir)
           (idris-toggle-semantic-source-highlighting)
           (let ((result
-                 (idris-user-eval
+                 (idris-eval
                   (if idris-load-to-here
                       `(:load-file ,fn ,(idris-get-line-num idris-load-to-here))
                     `(:load-file ,fn))))
@@ -288,6 +288,8 @@ This sets the load position to point, if there is one."
   (let* ((ty (idris-eval (list command name)))
          (result (car ty))
          (formatting (cdr ty)))
+    (when (member 'warnings-tree idris-warnings-printing)
+      (idris-list-compiler-notes))
     (idris-show-info (format "%s" result) formatting)))
 
 
@@ -1401,8 +1403,13 @@ of the term to replace."
 (defun idris-user-eval (what &optional no-errors)
   "Send WHAT to Idris process and return first item in the response.
 
+When `idris-warnings-printing' includes `warnings-tree' it also
+ calls `idris-list-compiler-notes' to display or update existing Idris notes.
+
 If `NO-ERRORS' is non-nil, don't raise `ERROR' if there was an Idris error."
   (let ((ty (idris-eval what no-errors)))
+    (when (member 'warnings-tree idris-warnings-printing)
+      (idris-list-compiler-notes))
     (car ty)))
 
 (provide 'idris-commands)

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -271,7 +271,7 @@ This sets the load position to point, if there is one."
           (idris-switch-working-directory srcdir)
           (idris-toggle-semantic-source-highlighting)
           (let ((result
-                 (idris-eval
+                 (idris-user-eval
                   (if idris-load-to-here
                       `(:load-file ,fn ,(idris-get-line-num idris-load-to-here))
                     `(:load-file ,fn))))
@@ -323,9 +323,9 @@ printing definition of a type at point."
 
 (defun idris-who-calls-name (name)
   "Show the callers of NAME in a tree."
-  (let* ((callers (idris-eval `(:who-calls ,name)))
+  (let* ((callers (idris-user-eval `(:who-calls ,name)))
          (roots (mapcar #'(lambda (c) (idris-caller-tree c :who-calls))
-                        (car callers))))
+                        callers)))
     (if (not (null roots))
         (idris-tree-info-show-multiple roots "Callers")
       (message "The name %s was not found." name))
@@ -340,8 +340,8 @@ printing definition of a type at point."
 
 (defun idris-name-calls-who (name)
   "Show the callees of NAME in a tree."
-  (let* ((callees (idris-eval `(:calls-who ,name)))
-         (roots (mapcar #'(lambda (c) (idris-caller-tree c :calls-who)) (car callees))))
+  (let* ((callees (idris-user-eval `(:calls-who ,name)))
+         (roots (mapcar #'(lambda (c) (idris-caller-tree c :calls-who)) callees)))
     (if (not (null roots))
         (idris-tree-info-show-multiple roots "Callees")
       (message "The name %s was not found." name))
@@ -514,9 +514,9 @@ Useful for writing papers or slides."
         (user-error "Width must be positive")
       (if (< (length what) 1)
           (user-error "Nothing to pretty-print")
-        (let ((text (idris-eval `(:interpret ,(concat ":pprint " fmt " " width " " what)))))
+        (let ((text (idris-user-eval `(:interpret ,(concat ":pprint " fmt " " width " " what)))))
           (with-idris-info-buffer
-            (insert (car text))
+            (insert text)
             (goto-char (point-min))
             (re-search-forward (if (string= fmt "latex")
                                    "% START CODE\n"
@@ -536,7 +536,7 @@ Useful for writing papers or slides."
   (let ((what (idris-thing-at-point)))
     (when (car what)
       (idris-load-file-sync)
-      (let ((result (car (idris-eval `(:case-split ,(cdr what) ,(car what)))))
+      (let ((result (idris-user-eval `(:case-split ,(cdr what) ,(car what))))
             (initial-position (point)))
         (if (<= (length result) 2)
             (message "Can't case split %s" (car what))
@@ -552,7 +552,7 @@ Useful for writing papers or slides."
   (let ((what (idris-thing-at-point)))
     (when (car what)
       (idris-load-file-sync)
-      (let ((result (car (idris-eval `(:make-case ,(cdr what) ,(car what))))))
+      (let ((result (idris-user-eval `(:make-case ,(cdr what) ,(car what)))))
         (if (<= (length result) 2)
             (message "Can't make cases from %s" (car what))
           (delete-region (line-beginning-position) (line-end-position))
@@ -601,7 +601,7 @@ If no indentation is found, return the empty string."
         (command (if proof :add-proof-clause :add-clause)))
     (when (car what)
       (idris-load-file-sync)
-      (let ((result (string-trim-left (car (idris-eval `(,command ,(cdr what) ,(car what))))))
+      (let ((result (string-trim-left (idris-user-eval `(,command ,(cdr what) ,(car what)))))
             final-point
             (prefix (idris-line-indentation-for what)))
         ;; Go forward until we get to a line with equal or less indentation to
@@ -627,7 +627,7 @@ If no indentation is found, return the empty string."
   (let ((what (idris-thing-at-point)))
     (when (car what)
       (idris-load-file-sync)
-      (let ((result (car (idris-eval `(:add-missing ,(cdr what) ,(car what))))))
+      (let ((result (idris-user-eval `(:add-missing ,(cdr what) ,(car what)))))
         (forward-line 1)
         (insert result)))))
 
@@ -637,7 +637,7 @@ If no indentation is found, return the empty string."
   (let ((what (idris-thing-at-point)))
     (when (car what)
       (idris-load-file-sync)
-      (let ((result (car (idris-eval `(:make-with ,(cdr what) ,(car what))))))
+      (let ((result (idris-user-eval `(:make-with ,(cdr what) ,(car what)))))
         (beginning-of-line)
         (kill-line)
         (insert result)))))
@@ -648,7 +648,7 @@ If no indentation is found, return the empty string."
   (let ((what (idris-thing-at-point)))
     (when (car what)
       (idris-load-file-sync)
-      (let* ((result (car (idris-eval `(:make-lemma ,(cdr what) ,(car what)))))
+      (let* ((result (idris-user-eval `(:make-lemma ,(cdr what) ,(car what))))
              (lemma-type (car result)))
         ;; There are two cases here: either a ?hole, or the {name} of a provisional defn.
         (cond ((equal lemma-type :metavariable-lemma)
@@ -768,11 +768,9 @@ A plain prefix ARG causes the command to prompt for hints and recursion
         (what (idris-thing-at-point)))
     (when (car what)
       (idris-load-file-sync)
-
-      (let ((result (car (if (> idris-protocol-version 1)
-                             (idris-eval `(:proof-search ,(cdr what) ,(car what)))
-                           (idris-eval `(:proof-search ,(cdr what) ,(car what) ,hints ,@depth))
-                           ))))
+      (let ((result (idris-user-eval (if (> idris-protocol-version 1)
+                                         `(:proof-search ,(cdr what) ,(car what))
+                                       `(:proof-search ,(cdr what) ,(car what) ,hints ,@depth)))))
         (if (string= result "")
             (user-error "Nothing found")
           (idris-replace-hole-with result))))))
@@ -783,7 +781,7 @@ Idris 2 only."
   (interactive)
   (if (not proof-region-start)
       (user-error "You must proof search first before looking for subsequent proof results")
-    (let ((result (car (idris-eval `:proof-search-next))))
+    (let ((result (idris-user-eval `:proof-search-next)))
       (save-excursion
         (goto-char proof-region-start)
         (delete-region proof-region-start proof-region-end)
@@ -800,7 +798,7 @@ Idris 2 only."
   (let ((what (idris-thing-at-point)))
     (when (car what)
       (idris-load-file-sync)
-      (let ((result (car (idris-eval `(:generate-def ,(cdr what) ,(car what)))))
+      (let ((result (idris-user-eval `(:generate-def ,(cdr what) ,(car what))))
             final-point
             (prefix (idris-line-indentation-for what)))
         (if (string= result "")
@@ -825,7 +823,7 @@ Idris 2 only."
   (interactive)
   (if (not def-region-start)
       (user-error "You must program search first before looking for subsequent program results")
-    (let ((result (car (idris-eval `:generate-def-next))))
+    (let ((result (idris-user-eval `:generate-def-next)))
       (save-excursion
         (goto-char def-region-start)
         (delete-region def-region-start def-region-end)
@@ -840,7 +838,7 @@ Idris 2 only."
     (unless (car what)
       (user-error "Could not find a hole at point to refine by"))
     (idris-load-file-sync)
-    (let ((results (car (idris-eval `(:intro ,(cdr what) ,(car what))))))
+    (let ((results (idris-user-eval `(:intro ,(cdr what) ,(car what)))))
       (pcase results
         (`(,result) (idris-replace-hole-with result))
         (_ (idris-replace-hole-with (ido-completing-read "I'm hesitating between: " results)))))))
@@ -852,7 +850,7 @@ Idris 2 only."
     (unless (car what)
       (user-error "Could not find a hole at point to refine by"))
     (idris-load-file-sync)
-    (let ((result (car (idris-eval `(:refine ,(cdr what) ,(car what) ,name)))))
+    (let ((result (idris-user-eval `(:refine ,(cdr what) ,(car what) ,name))))
       (idris-replace-hole-with result))))
 
 (defun idris-identifier-backwards-from-point ()
@@ -907,7 +905,7 @@ type-correct, so loading will fail."
   (interactive)
   (when (idris-current-buffer-dirty-p)
     (idris-load-file-sync))
-  (idris-hole-list-show (car (idris-eval '(:metavariables 80)))))
+  (idris-hole-list-show (idris-user-eval '(:metavariables 80))))
 
 (defun idris-list-compiler-notes ()
   "Show the compiler notes in tree view."
@@ -1399,6 +1397,13 @@ of the term to replace."
                        (save-excursion
                          (idris-show-core-term
                           (idris--active-term-beginning tt-term pos)))))))))))
+
+(defun idris-user-eval (what &optional no-errors)
+  "Send WHAT to Idris process and return first item in the response.
+
+If `NO-ERRORS' is non-nil, don't raise `ERROR' if there was an Idris error."
+  (let ((ty (idris-eval what no-errors)))
+    (car ty)))
 
 (provide 'idris-commands)
 ;;; idris-commands.el ends here

--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -305,11 +305,9 @@ versions cannot deal with that."
 (defvar idris-stack-eval-tags nil
   "List of stack-tags of continuations waiting on the stack.")
 
-(autoload 'idris-list-compiler-notes "idris-commands.el")
 (defun idris-eval (sexp &optional no-errors)
   "Evaluate SEXP on the inferior Idris and return the result.
-If `NO-ERRORS' is non-nil, don't trigger warning buffers and
- don't call `ERROR' if there was an Idris error."
+If `NO-ERRORS' is non-nil, don't call `ERROR' if there was an Idris error."
   (let* ((tag (gensym (format "idris-result-%d-"
                               (1+ idris-continuation-counter))))
          (idris-stack-eval-tags (cons tag idris-stack-eval-tags)))
@@ -326,11 +324,10 @@ If `NO-ERRORS' is non-nil, don't trigger warning buffers and
               (error "Reply to canceled synchronous eval request tag=%S sexp=%S"
                      tag sexp))))
          ((:error condition &optional _spans)
-          (if no-errors
-              (throw tag (list #'identity nil))
-            (when (member 'warnings-tree idris-warnings-printing)
-              (idris-list-compiler-notes))
-            (throw tag (list #'error "%s (synchronous Idris evaluation failed)" condition)))))
+          (throw tag (if no-errors
+                         ;; TODO: better way to communicate error upstream
+                         (list #'identity (cons :error condition))
+                       (list #'user-error "%s (synchronous Idris evaluation failed)" condition)))))
        (let ((debug-on-quit t)
              (inhibit-quit nil))
          (while t


### PR DESCRIPTION
This will allow us to:

* **Globally handle** updating Idris notes when needed.
* **Remove** the (cyclic) dependency of `inferior-idris.el` on `idris-list-compiler-notes`.
* **Remove duplication**.
* **Unify and improve** response handling for user commands.

This is also part of making the switch to the `repl` command more **robust and user-friendly**.

**Currently**, if a user invokes `idris-switch-to-repl` in an Idris file that contains an error, **the switch fails** and the notes buffer appears.

**Expected Behaviour:** The switch to the buffer should **succeed** regardless of errors, and the user should only be **unobtrusively notified**. This will be implemented in separated pull request as separate change.