### PR TITLE
Add tiny pause between sending messages to Idris process

### DIFF
--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -198,6 +198,10 @@ This is maintained to restart Idris when the arguments change.")
   (let* ((msg (concat (idris-prin1-to-string sexp) "\n"))
          (string (concat (idris-encode-length (length msg)) msg)))
     (idris-event-log sexp t)
+    ;; TODO: get this fixed in Idris2 and remove the sleep
+    ;; Workaround to give Idris time to process previous message
+    ;; https://discord.com/channels/827106007712661524/859010945173815306/1452330258555736135
+    (sleep-for 0.0001)
     (process-send-string proc string)))
 
 (defun idris-encode-length (n)


### PR DESCRIPTION
Hotfix to prevent getting Idris stuck
when Idris reads more data received in stream it gets hung on
This happens when emacs sends messages quickly in succession 
https://discord.com/channels/827106007712661524/1451313072323952722/1452327616014192742

Output from strace when idris2 get stuck.
```
read(5, "000013((:get-options) 6)\n000018("..., 4096) = 55
lseek(5, -30, SEEK_CUR)                 = -1 ESPIPE (Illegal seek)
```
When it process messages normally

```
read(5, "000013((:get-options) 6)\n", 4096) = 25
write(5, "00009b(:return (:ok ((:show-impl"..., 161) = 161
read(5, "000018((:metavariables 80) 7)\n", 4096) = 30
```