### PR TITLE
Use string-bytes to compute length of message to Idris

### DIFF
--- a/inferior-idris.el
+++ b/inferior-idris.el
@@ -196,7 +196,7 @@ This is maintained to restart Idris when the arguments change.")
 (defun idris-send (sexp proc)
   "Send a SEXP to Idris over the PROC. This is the lowest level of communication."
   (let* ((msg (concat (idris-prin1-to-string sexp) "\n"))
-         (string (concat (idris-encode-length (length msg)) msg)))
+         (string (concat (idris-encode-length (string-bytes msg)) msg)))
     (idris-event-log sexp t)
     (process-send-string proc string)))
 


### PR DESCRIPTION
Non-ASCII text uses multiple bytes (e.g. "ab" → 2 bytes, "你好" → 6 bytes in UTF-8). 
Idris process the data "in bytes"" and when using `lenght` we were declaring incorrect length of the message causing Idris to get stuck in an infinite loop

Output from strace:
```
 read(5, "000017((:interpret \"\344\275\240\345\245\275\") 19)"..., 4096) = 33
clock_gettime(CLOCK_PROCESS_CPUTIME_ID, {tv_sec=0, tv_nsec=626738303}) = 0
lseek(5, -4, SEEK_CUR)                  = -1 ESPIPE (Illegal seek)
lseek(5, -4, SEEK_CUR)                  = -1 ESPIPE (Illegal seek)
lseek(5, -4, SEEK_CUR)                  = -1 ESPIPE (Illegal seek)
lseek.. forever
```

Before this change:
- Idris get stuck when user types non ascii characters in repl

After this change:
- Idris is able to receive message and return response back.

Response from `Idris` 
```
λΠ> 你好
Error: Undefined name ä½. 

(Interactive):1:1--1:3
 1 | ä½ å¥½
     ^^
λΠ> 
```
Note: we still have some encoding issue see ^ where seems like instead of `你好` Idris received `ä½`
But that we can fix separately.

Fixes: https://github.com/idris-hackers/idris-mode/issues/657