### PR TITLE
Do not error in idris-repl when Idris does not return back a string

### DIFF
--- a/idris-repl.el
+++ b/idris-repl.el
@@ -393,9 +393,16 @@ and semantic annotations PROPS."
                  ,props)
                (idris-repl-highlight-input
                 start start-line start-col end-line end-col props))))))
-       (_ (idris-repl-insert-result (or result "") spans)))) ;; The actual result
+       ((pred listp) (idris-repl-insert-list-result result spans))
+       ((pred stringp) (idris-repl-insert-result result spans))
+       (_ (progn
+            (message "Unable process result from Idris. \n%s" result)
+            (idris-repl-insert-prompt)))))
     ((:error condition &optional spans)
      (idris-repl-show-abort condition spans))))
+
+(defun idris-repl-insert-list-result (lst spans)
+  (idris-repl-insert-result (mapconcat (lambda (l) (format "%s" l)) lst "\n")) spans)
 
 (defun idris-repl-show-abort (condition &optional highlighting)
   (with-current-buffer (idris-repl-buffer)


### PR DESCRIPTION
Currently, when a user runs Idris REPL commands such as `:opts` or `:version`, idris-mode throws an error because Idris returns a list instead of a string.

While the ideal fix would be to update Idris2 to always return a string response for the `:interpret` command, this change provides a "good enough" intermediate solution that improves the user experience.

### Before:

<img width="977" height="297" alt="error-opts" src="https://github.com/user-attachments/assets/844c930d-a774-44d1-ba0e-75e4c70667d5" />

<img width="830" height="164" alt="error-version" src="https://github.com/user-attachments/assets/eee3f875-5001-4b9b-8ea0-9ebb1e6ab59f" />

### After the change:

<img width="465" height="316" alt="after-fix-version-opts" src="https://github.com/user-attachments/assets/cfe401a8-58bc-4ae4-a758-54f9d3cfdb1c" />

#### Relates to:
https://github.com/idris-hackers/idris-mode/issues/661

Idris2 code https://github.com/idris-lang/Idris2/blob/214eb45472e15187e6f932c6820a0f0d5542a18e/src/Idris/IDEMode/REPL.idr#L141