### PR TITLE
[xref] Add xref lookup to Idris supporting buffers and 

### DIFF
--- a/idris-hole-list.el
+++ b/idris-hole-list.el
@@ -30,6 +30,7 @@
 (require 'idris-keys)
 (require 'idris-warnings-tree)
 (require 'idris-settings)
+(require 'idris-xref)
 
 (defvar idris-hole-list-buffer-name (idris-buffer-name :holes)
   "The name of the buffer containing Idris holes.")
@@ -66,7 +67,8 @@
   "Major mode used for transient Idris hole list buffers.
 \\{idris-hole-list-mode-map}
 Invokes `idris-hole-list-mode-hook'."
-  (setq-local prop-menu-item-functions '(idris-context-menu-items)))
+  (setq-local prop-menu-item-functions '(idris-context-menu-items))
+  (add-hook 'xref-backend-functions #'idris-xref-backend nil 'local))
 
 ;; TODO: Auto detect mode for idris holes buffer instead of
 ;; invoking `idris-hole-list-mode' in `idris-hole-list-show'

--- a/idris-info.el
+++ b/idris-info.el
@@ -28,6 +28,7 @@
 (require 'prop-menu)
 (require 'idris-core)
 (require 'idris-common-utils)
+(require 'idris-xref)
 (require 'help-mode)
 
 (defvar idris-info-buffer-name (idris-buffer-name :info)
@@ -56,7 +57,7 @@
 \\{idris-info-mode-map}
 Invokes `idris-info-mode-hook'."
   (setq-local prop-menu-item-functions '(idris-context-menu-items))
-  (set (make-local-variable 'prop-menu-item-functions) '(idris-context-menu-items)))
+  (add-hook 'xref-backend-functions #'idris-xref-backend nil 'local))
 
 (defun idris-info-buffer ()
   "Return Idris info buffer."

--- a/idris-warnings-tree.el
+++ b/idris-warnings-tree.el
@@ -31,6 +31,7 @@
 (require 'idris-core)
 (require 'idris-warnings)
 (require 'idris-common-utils)
+(require 'idris-xref)
 
 (defvar idris-notes-buffer-name (idris-buffer-name :notes)
   "The name of the buffer containing Idris errors.")
@@ -99,7 +100,8 @@
   "Major mode for displaying Idris compiler notes.
 \\{idris-compiler-notes-mode-map}
 Invokes `idris-compiler-notes-mode-hook'."
-  (setq-local prop-menu-item-functions '(idris-context-menu-items)))
+  (setq-local prop-menu-item-functions '(idris-context-menu-items))
+  (add-hook 'xref-backend-functions #'idris-xref-backend nil 'local))
 
 (defun idris-compiler-notes-show-details ()
   (interactive)

--- a/idris-xref.el
+++ b/idris-xref.el
@@ -61,8 +61,14 @@ set `idris-xref-idris-source-location' instead."
   'idris)
 
 (cl-defmethod xref-backend-identifier-at-point ((_backend (eql idris)))
-  "Alias for `idris-name-at-point'."
-  (idris-name-at-point))
+  "Return the relevant identifier at point.
+
+Parse and sanitizes output from `idris-name-at-point'."
+  ;; name-at in idris2 doesn't like namespace and () around the thing
+  ;; When (idris-name-at-point) returns `Foo.(Bar)` we want to search for "Bar"
+  (let ((parts (cl-remove-if #'string-empty-p
+                             (split-string (idris-name-at-point) "\\."))))
+    (string-trim (car (last parts)) "[({]" "[})]")))
 
 (cl-defmethod xref-backend-definitions ((_backend (eql idris)) symbol)
   "Return a list of Xref objects candidates matching SYMBOL."


### PR DESCRIPTION
improve the `xref-backend-identifier-at-point` implementation for Idris.

Why:

To improve user experience by successfully finding source for more things.