### PR TITLE
Make `idris-proof-search-next` work again.

### DIFF
--- a/idris-commands.el
+++ b/idris-commands.el
@@ -785,14 +785,12 @@ Idris 2 only."
   (if (not proof-region-start)
       (user-error "You must proof search first before looking for subsequent proof results")
     (let ((result (car (idris-eval `:proof-search-next))))
-      (if (string= result "No more results")
-          (message "No more results")
-        (save-excursion
-          (goto-char proof-region-start)
-          (delete-region proof-region-start proof-region-end)
-          (setq proof-region-start (point))
-          (insert result)
-          (setq proof-region-end (point)))))))
+      (save-excursion
+        (goto-char proof-region-start)
+        (delete-region proof-region-start proof-region-end)
+        (setq proof-region-start (point))
+        (insert result)
+        (setq proof-region-end (point))))))
 
 (defvar-local def-region-start nil)
 (defvar-local def-region-end nil)
@@ -829,14 +827,12 @@ Idris 2 only."
   (if (not def-region-start)
       (user-error "You must program search first before looking for subsequent program results")
     (let ((result (car (idris-eval `:generate-def-next))))
-      (if (string= result "No more results")
-          (message "No more results")
-        (save-excursion
-          (goto-char def-region-start)
-          (delete-region def-region-start def-region-end)
-          (setq def-region-start (point))
-          (insert result)
-          (setq def-region-end (point)))))))
+      (save-excursion
+        (goto-char def-region-start)
+        (delete-region def-region-start def-region-end)
+        (setq def-region-start (point))
+        (insert result)
+        (setq def-region-end (point))))))
 
 (defun idris-intro ()
   "Introduce the unambiguous constructor to use in this hole."

--- a/idris-commands.el
+++ b/idris-commands.el
@@ -734,6 +734,11 @@ If no indentation is found, return the empty string."
         (idris-repl-eval-string (format ":exec %s" name) 0))
     (idris-eval '(:interpret ":exec"))))
 
+(defvar-local proof-region-start nil
+  "The start position of the last proof region.")
+(defvar-local proof-region-end nil
+  "The end position of the last proof region.")
+
 (defun idris-replace-hole-with (expr)
   "Replace the hole under the cursor by some EXPR."
   (save-excursion
@@ -741,12 +746,9 @@ If no indentation is found, return the empty string."
           (end (progn (forward-char) (search-forward-regexp "[^a-zA-Z0-9_']")
                       (backward-char) (point))))
       (delete-region start end))
-    (insert expr)))
-
-(defvar-local proof-region-start nil
-  "The start position of the last proof region.")
-(defvar-local proof-region-end nil
-  "The end position of the last proof region.")
+    (setq proof-region-start (point))
+    (insert expr)
+    (setq proof-region-end (point))))
 
 (defun idris-proof-search (&optional arg)
   "Invoke the proof search.

--- a/test/idris-commands-test.el
+++ b/test/idris-commands-test.el
@@ -544,6 +544,39 @@ third definition
         (advice-remove 'idris-load-file-sync #'idris-load-file-sync-stub)
         (advice-remove 'idris-eval #'idris-eval-stub)))))
 
+(ert-deftest idris-proof-search-next ()
+  "Test `idris-proof-search-next'."
+  (skip-unless (string-match-p "idris2$" idris-interpreter-path))
+  (let (eval-result)
+    (cl-flet ((idris-load-file-sync-stub () nil)
+              (idris-eval-stub (sexp &optional no-errors)
+                (apply #'funcall eval-result)))
+      (advice-add 'idris-load-file-sync :override #'idris-load-file-sync-stub)
+      (advice-add 'idris-eval :override #'idris-eval-stub)
+      (unwind-protect
+          (with-temp-buffer
+            (insert "data Foo = A | B
+
+testf : Foo -> Int
+testf x = ?hole1
+")
+            (goto-char (point-min))
+            (re-search-forward "hole")
+            (setq eval-result (list #'identity '("42")))
+            (funcall-interactively 'idris-proof-search)
+            (should (string-match-p "testf x = 42"
+                                    (buffer-substring-no-properties (point-min) (point-max))))
+            (setq eval-result (list #'identity '("1337")))
+            (funcall-interactively 'idris-proof-search-next)
+            (should (string-match-p "testf x = 1337"
+                                    (buffer-substring-no-properties (point-min) (point-max))))
+
+            (setq eval-result (list #'error "%s (synchronous Idris evaluation failed)" "No more results"))
+            (should-error (funcall-interactively 'idris-proof-search-next)))
+
+        (advice-remove 'idris-load-file-sync #'idris-load-file-sync-stub)
+        (advice-remove 'idris-eval #'idris-eval-stub)))))
+
 ;; Tests by Yasuhiko Watanabe
 ;; https://github.com/idris-hackers/idris-mode/pull/537/files
 (idris-ert-command-action "test-data/CaseSplit.idr" idris-case-split idris-test-eq-buffer)


### PR DESCRIPTION
When porting some code from idris2-mode few years back https://github.com/idris-hackers/idris-mode/pull/578 accidentally were removed marks from `idris-proof-search` required for `idris-proof-search-next`

This PR restores the functionality add test for the `idris-proof-search-next` and removes dead code.

Before:

<img width="1069" height="598" alt="output-2026-05-04-16:54:46" src="https://github.com/user-attachments/assets/9583d8a0-bf76-4494-b6c1-5eb2d297e75a" />


After:

<img width="1069" height="616" alt="output-2026-05-04-16:49:50" src="https://github.com/user-attachments/assets/fc6a61f6-ba50-4235-92d6-8aedef88b8e1" />
