### PR TITLE
Improve repl completion by complete only current word in multi-token input, not whole input

### DIFF
--- a/idris-repl.el
+++ b/idris-repl.el
@@ -334,12 +334,28 @@ Invokes `idris-repl-mode-hook'."
 (defun idris-repl-complete ()
   "Completion of the current input."
   (when idris-completion-via-compiler
-    (let* ((input (idris-repl-current-input))
-           (result (idris-eval `(:repl-completions ,input))))
-      (cl-destructuring-bind (completions partial) (car result)
-        (if (null completions)
-            nil
-          (list (+ idris-input-start (length partial)) (point-max) completions))))))
+    (when-let* ((thing (idris-repl--thing-to-complete))
+                (result (idris-eval `(:repl-completions ,(car thing)))))
+      (pcase (car result)
+        (`(,completions ,partial)
+         (when completions
+           (list (+ (cdr thing) (length partial)) (point-max) completions)))))))
+
+(defun idris-repl--thing-to-complete ()
+  (let ((input (idris-repl-current-input)))
+    (if (string-match-p "\\s-" input)
+        (when-let* ((bounds (idris-repl--word-bounds)))
+          (cons (buffer-substring-no-properties (car bounds) (cdr bounds))
+                (car bounds)))
+      (cons input idris-input-start))))
+
+(defun idris-repl--word-bounds ()
+  "Return (START . END) of the Idris identifier at point, or nil."
+  (save-excursion
+    (let ((end (point)))
+      (skip-chars-backward "[:alnum:]_.'")
+      (unless (= (point) end)
+        (cons (point) end)))))
 
 (defun idris-repl-begin-of-prompt ()
   "Go to the beginning of line or the prompt."


### PR DESCRIPTION

Previously, completion always sent the entire REPL input to the compiler.
For example:

```
Idris>
Idris> :doc prin
```
When we try to complete `prin` we used to send to Idris `(:repl-completions ":doc prin")` which fails.

Now, when the input contains whitespace, completion operates on the identifier at point instead.
After change we send only `(:repl-completions "prin")` which gives us back `(:ok (("printLn" "print") ""))`.

#### In Emacs before:

<img width="630" height="401" alt="repl-complete-before" src="https://github.com/user-attachments/assets/5b4b5139-cf62-4609-bb9c-bd0d3ef2694c" />


#### After change

<img width="1303" height="510" alt="output-2026-05-05-20:40:44" src="https://github.com/user-attachments/assets/378640cd-9c4a-4332-8018-33733a530934" />
